### PR TITLE
chore(release): 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-02-26
+
 ### Added
 
 - Evidence-grounded links that only open validated `file`/`url` targets.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-tacos",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-tacos",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "markdown-it": "^14.1.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "TaCoS Resume Brief",
   "description": "Auto task-context summaries when you resume work in VS Code.",
   "license": "MIT",
-  "version": "0.0.3",
+  "version": "0.1.0",
   "publisher": "jkordish",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump extension version from `0.0.3` to `0.1.0`
- roll current changelog entries from `Unreleased` into `0.1.0` dated section
- keep a fresh `Unreleased` heading for next work cycle

## Validation
- npm run verify:quick

## Notes
- `v0.1.0` tag has been created.
- This change does **not** publish to VS Code Marketplace.
