### PR TITLE
Stabilization: companion nudge suppression correctness coverage (#76)

### DIFF
--- a/test/companionNudges.test.ts
+++ b/test/companionNudges.test.ts
@@ -16,83 +16,144 @@ function buildSummary(overrides: Partial<ResumeSummary> = {}): ResumeSummary {
   };
 }
 
+type NudgeInput = Parameters<typeof chooseCompanionNudges>[0];
+
+function buildInput(overrides: Partial<NudgeInput> = {}): NudgeInput {
+  return {
+    summary: buildSummary(),
+    provider: 'local',
+    mode: 'active',
+    now: 1_700_000_000_000,
+    enabled: true,
+    aggressiveness: 'balanced',
+    quietHours: '',
+    cooldownMinutes: 10,
+    lastShownAt: 0,
+    ...overrides,
+  };
+}
+
 describe('chooseCompanionNudges', () => {
-  it('is deterministic for the same summary state', () => {
+  it('is deterministic for the same summary state and ranking', () => {
     const summary = buildSummary({
       lastFailingCommand: 'npm test -- auth',
       currentBranch: 'feature/auth',
       previousBranch: 'main',
     });
 
-    const first = chooseCompanionNudges({
-      summary,
-      provider: 'local',
-      mode: 'active',
-      now: 1_700_000_000_000,
-      enabled: true,
-      aggressiveness: 'balanced',
-      quietHours: '',
-      cooldownMinutes: 10,
-      lastShownAt: 0,
-    });
-    const second = chooseCompanionNudges({
-      summary,
-      provider: 'local',
-      mode: 'active',
-      now: 1_700_000_000_000,
-      enabled: true,
-      aggressiveness: 'balanced',
-      quietHours: '',
-      cooldownMinutes: 10,
-      lastShownAt: 0,
-    });
+    const first = chooseCompanionNudges(buildInput({ summary }));
+    const second = chooseCompanionNudges(buildInput({ summary }));
 
     expect(first).toEqual(second);
     expect(first.primary?.id).toBe('fix-failing-command');
+    expect(first.secondary?.id).toBe('branch-switch');
   });
 
-  it('suppresses nudges when within cooldown window', () => {
-    const result = chooseCompanionNudges({
-      summary: buildSummary({
-        lastFailingCommand: 'npm test',
+  it('suppresses nudges when feature is disabled', () => {
+    const result = chooseCompanionNudges(buildInput({ enabled: false }));
+
+    expect(result.primary).toBeUndefined();
+    expect(result.suppressedReason).toBe('disabled');
+  });
+
+  it.each(['paused', 'restricted', 'disabled'] as const)(
+    'suppresses nudges outside active mode (%s)',
+    (mode) => {
+      const result = chooseCompanionNudges(buildInput({ mode }));
+
+      expect(result.primary).toBeUndefined();
+      expect(result.suppressedReason).toBe('inactive-mode');
+    },
+  );
+
+  it('suppresses nudges when within cooldown window and reports next eligible time', () => {
+    const result = chooseCompanionNudges(
+      buildInput({
+        summary: buildSummary({
+          lastFailingCommand: 'npm test',
+        }),
+        now: 1_700_000_000_000,
+        cooldownMinutes: 15,
+        lastShownAt: 1_699_999_500_000,
       }),
-      provider: 'local',
-      mode: 'active',
-      now: 1_700_000_000_000,
-      enabled: true,
-      aggressiveness: 'high',
-      quietHours: '',
-      cooldownMinutes: 15,
-      lastShownAt: 1_699_999_500_000,
-    });
+    );
 
     expect(result.primary).toBeUndefined();
     expect(result.suppressedReason).toBe('cooldown');
     expect(result.nextEligibleAt).toBe(1_699_999_500_000 + 15 * 60_000);
   });
 
+  it('allows nudges exactly at cooldown boundary', () => {
+    const cooldownMinutes = 5;
+    const lastShownAt = 1_699_999_700_000;
+    const now = lastShownAt + cooldownMinutes * 60_000;
+    const result = chooseCompanionNudges(
+      buildInput({
+        summary: buildSummary({
+          lastFailingCommand: 'npm test',
+        }),
+        cooldownMinutes,
+        lastShownAt,
+        now,
+      }),
+    );
+
+    expect(result.suppressedReason).toBeUndefined();
+    expect(result.primary?.id).toBe('fix-failing-command');
+  });
+
   it('suppresses nudges during quiet hours windows', () => {
     const januaryNightLocal = new Date(2026, 0, 10, 23, 30, 0).getTime();
-    const result = chooseCompanionNudges({
-      summary: buildSummary({
-        lastFailingCommand: 'npm test',
+    const result = chooseCompanionNudges(
+      buildInput({
+        summary: buildSummary({
+          lastFailingCommand: 'npm test',
+        }),
+        now: januaryNightLocal,
+        aggressiveness: 'high',
+        quietHours: '22:00-07:00',
+        cooldownMinutes: 5,
       }),
-      provider: 'local',
-      mode: 'active',
-      now: januaryNightLocal,
-      enabled: true,
-      aggressiveness: 'high',
-      quietHours: '22:00-07:00',
-      cooldownMinutes: 5,
-      lastShownAt: 0,
-    });
+    );
 
     expect(result.primary).toBeUndefined();
     expect(result.suppressedReason).toBe('quiet-hours');
   });
+
+  it('returns no-candidate when no items meet aggressiveness threshold', () => {
+    const result = chooseCompanionNudges(
+      buildInput({
+        summary: buildSummary({
+          nextSteps: [],
+        }),
+        aggressiveness: 'low',
+      }),
+    );
+
+    expect(result.primary).toBeUndefined();
+    expect(result.suppressedReason).toBe('no-candidate');
+  });
 });
 
 describe('quiet hour parser', () => {
+  it('parses standard and whitespace-padded ranges', () => {
+    expect(__test__.parseQuietHoursWindow('09:30-17:45')).toEqual({
+      startMinute: 570,
+      endMinute: 1065,
+    });
+    expect(__test__.parseQuietHoursWindow(' 22:00 - 07:00 ')).toEqual({
+      startMinute: 1320,
+      endMinute: 420,
+    });
+  });
+
+  it.each(['', 'bad', '25:00-07:00', '22:60-07:00', '22:00-22:00', '22:00'])(
+    'rejects invalid quiet-hour inputs: %s',
+    (value) => {
+      expect(__test__.parseQuietHoursWindow(value)).toBeUndefined();
+    },
+  );
+
   it('handles wrap-around ranges', () => {
     const januaryNightLocal = new Date(2026, 0, 10, 23, 30, 0).getTime();
     const januaryMorningLocal = new Date(2026, 0, 10, 6, 30, 0).getTime();
@@ -101,5 +162,13 @@ describe('quiet hour parser', () => {
     expect(__test__.isInQuietHours(januaryNightLocal, '22:00-07:00')).toBe(true);
     expect(__test__.isInQuietHours(januaryMorningLocal, '22:00-07:00')).toBe(true);
     expect(__test__.isInQuietHours(januaryDayLocal, '22:00-07:00')).toBe(false);
+  });
+
+  it('handles daytime ranges', () => {
+    const januaryMorningLocal = new Date(2026, 0, 10, 10, 0, 0).getTime();
+    const januaryLateLocal = new Date(2026, 0, 10, 17, 0, 0).getTime();
+
+    expect(__test__.isInQuietHours(januaryMorningLocal, '09:00-12:00')).toBe(true);
+    expect(__test__.isInQuietHours(januaryLateLocal, '09:00-12:00')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
Implements #76 stabilization by hardening companion nudge suppression correctness through deterministic, targeted test coverage for mode gating, quiet-hours handling, cooldown windows, and ranking behavior.

## What Changed
- expanded `test/companionNudges.test.ts` coverage to validate:
  - suppression when feature is disabled
  - suppression for non-active modes (`paused`, `restricted`, `disabled`)
  - cooldown suppression math and `nextEligibleAt` calculations
  - cooldown boundary behavior (eligible exactly at boundary)
  - deterministic ranking with stable primary/secondary ordering
  - `no-candidate` suppression when aggressiveness threshold filters all candidates
  - quiet-hours parsing success/failure cases, including whitespace and invalid windows
  - quiet-hours behavior for wrap-around and daytime windows

## Validation
- `npm run compile`
- `npm test -- companionNudges`

## Tracking
- Refs #76
- Refs #72
