### PR TITLE
UX: compact panel readability + action intent grouping (#77)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2558,7 +2558,8 @@ function renderWebview(
       : '';
 
   const restoreActionButtons = {
-    workingSet: '<button type="button" data-action="restoreWorkingSet">Restore working set</button>',
+    workingSet:
+      '<button type="button" data-action="restoreWorkingSet">Restore working set</button>',
     jumpToLastEdit: `<button type="button" data-action="restoreJumpToLastEdit" ${availability.canJumpToLastEdit ? '' : 'disabled aria-disabled="true"'}>Jump to last edit</button>`,
     reopenFiles: '<button type="button" data-action="restoreReopenFiles">Reopen files</button>',
     openChangedFiles:


### PR DESCRIPTION
## Summary
Implements #77 compact-panel UX tuning by improving scanability of the `Now / Next / Blocked / Restore` surface, regrouping actions by intent, and reducing panel refresh flicker/jump behavior.

## What Changed
- refined Companion Home readability:
  - `Now` block includes a compact focus cue + mode metadata
  - `Next` block keeps high-signal actions together (`Copy next steps`, `Copy prompt + open Codex`)
  - `Restore` block is grouped by intent (`Open`, `Run`, `Diagnose`) instead of one undifferentiated action list
- regrouped lower action surfaces by intent:
  - `Quick Actions` split into `Copy` and `Feedback`
  - `Restore Pack` split into `Open`, `Run`, `Diagnose`, and `Copy`
- reduced refresh flicker/jump behavior:
  - removed panel body refresh animation
  - persisted Evidence/Timeline expanded state across rerenders using webview state
- reduced visual duplication by removing the standalone `Intent` and `Summary Feedback` cards (content/actions preserved in other grouped surfaces)

## Validation
- `npm run compile`
- `npm run test:integration`

## Tracking
- Refs #77
- Refs #72
