### PR TITLE
Docs: 5-minute quickstart + README start-here links (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 TaCoS is a VS Code extension that helps you resume work quickly with an instant local summary, evidence-backed next steps, and optional AI refinement.
 
+## Start Here
+
+- [5-minute Quickstart](docs/quickstart.md)
+- [Privacy & Safety](docs/privacy-safety.md)
+
 ## Why TaCoS
 
 TaCoS is built around five non-negotiable principles:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,54 @@
+# TaCoS Quickstart (5 Minutes)
+
+This guide gets you from install to first useful resume summary quickly, while keeping privacy choices explicit.
+
+## Local-Only In 60 Seconds
+
+1. Open your project folder in VS Code.
+2. Open Command Palette and run `TaCoS: Set Privacy Preset`.
+3. Choose `Minimal` (recommended for first run).
+4. Run `TaCoS: Resume Summary Quick`.
+5. Open `TaCoS: Show Last Summary` if the panel is not already visible.
+
+What to expect:
+- You get an instant local summary (`Now`, `Next`, `Blocked`, `Restore`).
+- No AI payload is sent in local mode.
+
+## Optional AI In 2 Minutes
+
+Use this only if you want refinement beyond local-only summaries.
+
+1. Run `TaCoS: Configure AI Provider`.
+2. Choose `VS Code LM` or `OpenAI (direct API)`.
+3. If you choose OpenAI, run `TaCoS: Set OpenAI API Key`.
+4. Trigger a summary again with `TaCoS: Resume Summary Quick`.
+5. Review the generated `TaCoS: Review AI Payload` preview document.
+6. Choose one consent action:
+- `Send once`
+- `Always allow in this workspace`
+- `Do not send`
+
+Control later:
+- Run `TaCoS: Revoke AI Payload Consent` to require payload review again.
+- Run `TaCoS: Configure AI Provider` and switch back to `local` at any time.
+
+## Privacy Presets (Plain Language)
+
+Use `TaCoS: Set Privacy Preset` to switch.
+
+| Preset | What TaCoS Uses | Typical Use |
+| --- | --- | --- |
+| `Minimal` | No diff, no terminal history, no debug history, local summary provider | Default safest baseline |
+| `Balanced` | Terminal + debug history, no diff, local summary provider | More context without diff capture |
+| `Max Context` | Terminal + debug history + diff, local summary provider | Richest local context for hard resumes |
+
+Notes:
+- Presets control local collection defaults and set provider back to `local`.
+- In Restricted Mode, risky actions and AI refinement are blocked until workspace trust is granted.
+
+## Fast Sanity Check
+
+After setup, confirm:
+- `TaCoS` status bar entry appears.
+- `Companion Home` shows `Now / Next / Blocked / Restore`.
+- `TaCoS: Export Local Metrics` writes `.tacos/metrics.csv` when you want local adoption metrics.


### PR DESCRIPTION
## Summary
Implements #78 by adding a true 5-minute quickstart document and surfacing it prominently from the README.

## What Changed
- added `docs/quickstart.md` with:
  - **Local-only in 60 seconds** flow
  - **Optional AI in 2 minutes** flow, including payload preview + consent choices
  - plain-language privacy preset guidance (`Minimal`, `Balanced`, `Max Context`)
  - a fast sanity-check section for first-run validation
- updated `README.md` with a prominent **Start Here** section linking to:
  - `docs/quickstart.md`
  - `docs/privacy-safety.md`

## Validation
- `npm run format:check`

## Tracking
- Refs #78
- Refs #72
