### PR TITLE
Metrics: docs baseline + local summary script (#79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ Run `TaCoS: Export Local Metrics` to write:
 - `.tacos/metrics.json` (raw session records)
 - `.tacos/metrics.csv` (dashboard-friendly fields + derived rates)
 
+Docs:
+
+- `docs/metrics.md` (data dictionary + export workflow)
+- `docs/metrics-baseline.md` (dogfooding baseline template)
+
 Key companion fields:
 
 - `companionPromptImpressions`: prompt fallback impressions per session.

--- a/docs/metrics-baseline.md
+++ b/docs/metrics-baseline.md
@@ -1,0 +1,54 @@
+# Metrics Baseline (Dogfooding)
+
+This document records local dogfooding metrics used to evaluate TaCoS stabilization progress for `0.2.x`.
+
+## Minimum Sample Gate
+
+Before marking the epic gate complete:
+
+- `>= 30` metric sessions
+- `>= 3` distinct workspaces
+
+## How To Generate Baseline Summary
+
+1. Run `TaCoS: Export Local Metrics` in VS Code.
+2. From repo root, run:
+
+```bash
+npm run metrics:summary -- .tacos/metrics.csv
+```
+
+3. Paste the generated markdown snapshot into the "Current Baseline Snapshot" section below.
+4. Update the date and notes.
+
+## Current Baseline Snapshot
+
+Date: `TBD`
+Source CSV: `.tacos/metrics.csv`
+
+Status:
+- Dogfooding gate met: `TBD`
+- Sessions: `TBD`
+- Distinct workspaces: `TBD`
+
+Lag summary (ms):
+
+| Metric | n | p50 | p95 |
+| --- | ---: | ---: | ---: |
+| `firstMeaningfulEditLagMs` | TBD | TBD | TBD |
+| `firstRunLagMs` | TBD | TBD | TBD |
+| `firstActionLagMs` | TBD | TBD | TBD |
+
+Prompt and nudge rates:
+
+| Metric | Value |
+| --- | ---: |
+| Prompt impressions (total) | TBD |
+| Forced-open details clicks (total) | TBD |
+| Forced-open rate (`forced/prompt`) | TBD |
+| Nudge impressions (total) | TBD |
+| Nudge impressions per session | TBD |
+
+Notes:
+- Replace all `TBD` values with the latest local export summary before closing epic `#72`.
+- Keep this document local-context safe (no raw workspace paths in shared copies).

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,53 @@
+# Local Metrics Guide
+
+TaCoS metrics are local-only. No telemetry upload or external analytics pipeline is used.
+
+## Export Metrics
+
+1. Open Command Palette.
+2. Run `TaCoS: Export Local Metrics`.
+3. TaCoS writes:
+- `.tacos/metrics.json` (raw local records)
+- `.tacos/metrics.csv` (dashboard-friendly CSV)
+
+## CSV Data Dictionary
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `startedAtMs` | integer | Session start timestamp in Unix milliseconds. |
+| `startedAtIso` | string | Session start timestamp as ISO 8601. |
+| `sessionDate` | string | UTC date (`YYYY-MM-DD`) for daily grouping. |
+| `workspaceRoot` | string | Workspace root path for local grouping. |
+| `trigger` | enum | Summary trigger (`focus`, `manual`, `cached`). |
+| `uiSurface` | enum | UI surface mode (`statusbar`, `notification`, `silent`). |
+| `interruptionEvent` | integer | `1` when focus-triggered summary used notification prompt mode, else `0`/empty. |
+| `firstMeaningfulEditLagMs` | integer | Milliseconds from session start to first meaningful edit. |
+| `firstRunLagMs` | integer | Milliseconds from session start to first run/test/debug action. |
+| `firstActionLagMs` | integer | Milliseconds from session start to first meaningful action of any tracked type. |
+| `companionFirstActionLagMs` | integer | Milliseconds from session start to first companion action. |
+| `companionPromptImpressions` | integer | Number of prompt-mode companion impressions in session. |
+| `companionForcedOpenDetailsClicks` | integer | Number of "Open details" forced-open clicks from prompt mode. |
+| `companionQuickActionsTaken` | integer | Number of prompt-mode quick actions taken (copy/pause/open flows). |
+| `companionNudgeImpressions` | integer | Number of accepted companion nudge impressions in session. |
+| `helpfulnessRating` | integer | Optional local rating (`1`-`5`) from `TaCoS: Rate Summary Helpfulness`. |
+| `pauseActions` | integer | Count of pause actions taken during session. |
+| `snoozeActions` | integer | Count of snooze actions taken during session. |
+| `disableActions` | integer | Count of disable/toggle-off actions taken during session. |
+| `companionActionFollowThroughRate` | ratio | Derived as `companionQuickActionsTaken / companionPromptImpressions`. |
+| `companionForcedOpenRate` | ratio | Derived as `companionForcedOpenDetailsClicks / companionPromptImpressions`. |
+
+## Epic #72 Key Fields
+
+Track these explicitly for stabilization/adoption gating:
+
+- `firstMeaningfulEditLagMs`
+- `firstRunLagMs`
+- `firstActionLagMs`
+- `companionPromptImpressions`
+- `companionForcedOpenDetailsClicks`
+- `companionNudgeImpressions`
+
+## Notes
+
+- Empty values mean the metric was not observed in that session.
+- `workspaceRoot` is local-only and should be redacted/anonymized before public sharing.

--- a/package.json
+++ b/package.json
@@ -380,6 +380,7 @@
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"{src,test}/**/*.ts\" \"*.{json,md,yml,yaml,cjs}\"",
     "format:check": "prettier --check \"{src,test}/**/*.ts\" \"*.{json,md,yml,yaml,cjs}\"",
+    "metrics:summary": "node ./scripts/metrics-summary.mjs",
     "test": "jest --runInBand",
     "test:integration": "node ./test/integration/runTest.js",
     "verify:quick": "npm run format:check && npm run lint && npm run compile && npm test",

--- a/scripts/metrics-summary.mjs
+++ b/scripts/metrics-summary.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+function parseCsv(text) {
+  const rows = [];
+  let row = [];
+  let field = '';
+  let inQuotes = false;
+
+  for (let i = 0; i < text.length; i += 1) {
+    const char = text[i];
+
+    if (inQuotes) {
+      if (char === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i += 1;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += char;
+      }
+      continue;
+    }
+
+    if (char === '"') {
+      inQuotes = true;
+      continue;
+    }
+
+    if (char === ',') {
+      row.push(field);
+      field = '';
+      continue;
+    }
+
+    if (char === '\n') {
+      row.push(field);
+      rows.push(row);
+      row = [];
+      field = '';
+      continue;
+    }
+
+    if (char === '\r') {
+      continue;
+    }
+
+    field += char;
+  }
+
+  if (field.length > 0 || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+
+  return rows;
+}
+
+function toNumber(value) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return undefined;
+  }
+
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function quantile(values, p) {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = (sorted.length - 1) * p;
+  const low = Math.floor(index);
+  const high = Math.ceil(index);
+  if (low === high) {
+    return sorted[low];
+  }
+
+  const weight = index - low;
+  return sorted[low] + (sorted[high] - sorted[low]) * weight;
+}
+
+function formatNumber(value, digits = 2) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return value.toFixed(digits);
+}
+
+function formatMs(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+  return `${Math.round(value)} (${(value / 1000).toFixed(1)}s)`;
+}
+
+function summarizeLagRows(rows, field) {
+  const values = rows
+    .map((row) => toNumber(row[field]))
+    .filter((value) => typeof value === 'number');
+
+  return {
+    n: values.length,
+    p50: quantile(values, 0.5),
+    p95: quantile(values, 0.95),
+  };
+}
+
+function main() {
+  const inputPath = process.argv[2] || '.tacos/metrics.csv';
+  const csvPath = resolve(process.cwd(), inputPath);
+
+  let raw;
+  try {
+    raw = readFileSync(csvPath, 'utf8');
+  } catch (error) {
+    console.error(`Failed to read CSV at ${csvPath}: ${error.message}`);
+    process.exit(1);
+  }
+
+  const records = parseCsv(raw);
+  if (records.length < 2) {
+    console.error(`No metric rows found in ${csvPath}.`);
+    process.exit(1);
+  }
+
+  const [headers, ...dataRows] = records;
+  const rows = dataRows
+    .filter((row) => row.length > 1)
+    .map((values) => {
+      const row = {};
+      headers.forEach((header, index) => {
+        row[header] = values[index] ?? '';
+      });
+      return row;
+    });
+
+  const workspaceCount = new Set(
+    rows.map((row) => (row.workspaceRoot || '').trim()).filter((value) => value.length > 0),
+  ).size;
+
+  const lagMetrics = [
+    { field: 'firstMeaningfulEditLagMs', label: 'First meaningful edit lag' },
+    { field: 'firstRunLagMs', label: 'First run lag' },
+    { field: 'firstActionLagMs', label: 'First action lag' },
+  ].map((metric) => ({ ...metric, ...summarizeLagRows(rows, metric.field) }));
+
+  const promptsTotal = rows.reduce(
+    (sum, row) => sum + (toNumber(row.companionPromptImpressions) || 0),
+    0,
+  );
+  const forcedOpenTotal = rows.reduce(
+    (sum, row) => sum + (toNumber(row.companionForcedOpenDetailsClicks) || 0),
+    0,
+  );
+  const nudgeTotal = rows.reduce(
+    (sum, row) => sum + (toNumber(row.companionNudgeImpressions) || 0),
+    0,
+  );
+
+  const promptSessionCount = rows.filter(
+    (row) => (toNumber(row.companionPromptImpressions) || 0) > 0,
+  ).length;
+  const nudgeSessionCount = rows.filter(
+    (row) => (toNumber(row.companionNudgeImpressions) || 0) > 0,
+  ).length;
+
+  const forcedOpenRate = promptsTotal > 0 ? forcedOpenTotal / promptsTotal : undefined;
+  const promptPerSession = rows.length > 0 ? promptsTotal / rows.length : undefined;
+  const nudgePerSession = rows.length > 0 ? nudgeTotal / rows.length : undefined;
+  const dogfoodingGateMet = rows.length >= 30 && workspaceCount >= 3;
+
+  const lines = [
+    '# TaCoS Metrics Summary',
+    '',
+    `- Source: \`${csvPath}\``,
+    `- Sessions: ${rows.length}`,
+    `- Distinct workspaces: ${workspaceCount}`,
+    `- Dogfooding gate (>=30 sessions and >=3 workspaces): ${dogfoodingGateMet ? 'met' : 'not yet met'}`,
+    '',
+    '## Lag Baselines',
+    '',
+    '| Metric | n | p50 (ms / s) | p95 (ms / s) |',
+    '| --- | ---: | ---: | ---: |',
+    ...lagMetrics.map(
+      (metric) => `| ${metric.label} | ${metric.n} | ${formatMs(metric.p50)} | ${formatMs(metric.p95)} |`,
+    ),
+    '',
+    '## Companion Prompt and Nudge Rates',
+    '',
+    '| Metric | Value |',
+    '| --- | ---: |',
+    `| Prompt impressions (total) | ${promptsTotal} |`,
+    `| Sessions with prompt impressions | ${promptSessionCount} |`,
+    `| Prompt impressions per session | ${formatNumber(promptPerSession)} |`,
+    `| Forced-open details clicks (total) | ${forcedOpenTotal} |`,
+    `| Forced-open rate (forced opens / prompts) | ${formatNumber(forcedOpenRate, 4)} |`,
+    `| Nudge impressions (total) | ${nudgeTotal} |`,
+    `| Sessions with nudge impressions | ${nudgeSessionCount} |`,
+    `| Nudge impressions per session | ${formatNumber(nudgePerSession)} |`,
+  ];
+
+  process.stdout.write(`${lines.join('\n')}\n`);
+}
+
+main();


### PR DESCRIPTION
## Summary
Implements #79 by adding a local-metrics documentation baseline and a small script to turn `.tacos/metrics.csv` into a markdown summary with p50/p95 lag and prompt/nudge rates.

## What Changed
- added `docs/metrics.md`:
  - export workflow for `TaCoS: Export Local Metrics`
  - full CSV data dictionary
  - explicit key fields tied to epic success gates:
    - `firstMeaningfulEditLagMs`
    - `firstRunLagMs`
    - `firstActionLagMs`
    - `companionPromptImpressions`
    - `companionForcedOpenDetailsClicks`
    - `companionNudgeImpressions`
- added `docs/metrics-baseline.md`:
  - dogfooding minimum gate (`>=30` sessions across `>=3` workspaces)
  - repeatable baseline workflow
  - baseline snapshot template for p50/p95 + prompt/nudge rates
- added optional script `scripts/metrics-summary.mjs`:
  - reads local CSV export
  - outputs markdown summary with lag quantiles and companion rates
- added `npm` script:
  - `npm run metrics:summary -- .tacos/metrics.csv`
- added README pointers to the new metrics docs

## Validation
- `npm run metrics:summary -- /tmp/tacos-metrics-sample.csv` (smoke test on sample CSV)
- `npm run format:check`

## Tracking
- Refs #79
- Refs #72
