### PR TITLE
Feedback loop: issue templates + safe diagnostics command (#80)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Report a TaCoS bug with privacy-safe diagnostics.
+title: "bug: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the report. Please include diagnostics from `TaCoS: Copy Diagnostics`.
+        Do not paste secrets, raw terminal commands, or private file paths.
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: What did you expect, and what actually happened?
+      placeholder: Brief expected vs actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics bundle (`TaCoS: Copy Diagnostics`)
+      description: Paste the full output here.
+      render: text
+    validations:
+      required: true
+  - type: dropdown
+    id: trust_mode
+    attributes:
+      label: Workspace trust mode
+      options:
+        - trusted
+        - restricted
+        - not sure
+    validations:
+      required: true
+  - type: input
+    id: vscode_version
+    attributes:
+      label: VS Code version
+      placeholder: e.g. 1.99.0
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: TaCoS Privacy & Safety
+    url: https://github.com/jkordish/vscode-tacos/blob/main/docs/privacy-safety.md
+    about: Review privacy and safety behavior before reporting.

--- a/.github/ISSUE_TEMPLATE/metrics_share.yml
+++ b/.github/ISSUE_TEMPLATE/metrics_share.yml
@@ -1,0 +1,32 @@
+name: Metrics share (optional)
+description: Share local TaCoS metrics summary for stabilization/adoption review.
+title: "metrics: "
+labels:
+  - metrics
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Share aggregated local metrics only. Please avoid posting raw private file paths.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Metrics summary markdown
+      description: Paste output from `npm run metrics:summary -- .tacos/metrics.csv`.
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Add context (workflow type, whether this was dogfooding, etc.).
+    validations:
+      required: false
+  - type: checkboxes
+    id: privacy
+    attributes:
+      label: Privacy check
+      options:
+        - label: I removed any private workspace paths or secrets.
+          required: true

--- a/.github/ISSUE_TEMPLATE/ux_feedback.yml
+++ b/.github/ISSUE_TEMPLATE/ux_feedback.yml
@@ -1,0 +1,35 @@
+name: UX feedback
+description: Share confusion points or suggestions for TaCoS UX.
+title: "ux: "
+labels:
+  - ux
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: What were you trying to do?
+      placeholder: Describe your goal and workflow.
+    validations:
+      required: true
+  - type: textarea
+    id: confusion
+    attributes:
+      label: What was confusing?
+      placeholder: Which part was unclear or hard to find?
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect instead?
+      placeholder: Describe ideal behavior or wording.
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Optional diagnostics (`TaCoS: Copy Diagnostics`)
+      description: Helps us understand mode/provider/trust state.
+      render: text
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ TaCoS is built around five non-negotiable principles:
 - `TaCoS: Set OpenAI API Key`
 - `TaCoS: Clear OpenAI API Key`
 - `TaCoS: Export Local Metrics`
+- `TaCoS: Copy Diagnostics`
 
 ### Codex / ChatGPT Interop
 

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "onCommand:tacos.toggleEnabled",
     "onCommand:tacos.pauseUntilRestart",
     "onCommand:tacos.exportMetrics",
+    "onCommand:tacos.copyDiagnostics",
     "onCommand:tacos.addVisitedUrl",
     "onCommand:tacos.addCheckpointNote",
     "onCommand:tacos.addCheckpointNoteFromClipboard",
@@ -156,6 +157,10 @@
       {
         "command": "tacos.exportMetrics",
         "title": "TaCoS: Export Local Metrics"
+      },
+      {
+        "command": "tacos.copyDiagnostics",
+        "title": "TaCoS: Copy Diagnostics"
       },
       {
         "command": "tacos.addVisitedUrl",

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,142 @@
+import type { MetricRecord, SummaryProvider, UiSurface } from './types';
+
+export type CompanionRuntimeMode = 'active' | 'paused' | 'restricted' | 'disabled';
+
+export interface DiagnosticsInput {
+  generatedAt: number;
+  extensionVersion: string;
+  vscodeVersion: string;
+  workspaceTrusted: boolean;
+  summaryProvider: SummaryProvider;
+  uiSurface: UiSurface;
+  companionRuntimeMode: CompanionRuntimeMode;
+  metricsEnabled: boolean;
+  recentMetrics: MetricRecord[];
+}
+
+interface RecentMetricsSummary {
+  sessions: number;
+  firstMeaningfulEditLagP50Ms?: number;
+  firstMeaningfulEditLagP95Ms?: number;
+  firstRunLagP50Ms?: number;
+  firstRunLagP95Ms?: number;
+  firstActionLagP50Ms?: number;
+  firstActionLagP95Ms?: number;
+  companionPromptImpressionsTotal: number;
+  companionForcedOpenDetailsClicksTotal: number;
+  companionNudgeImpressionsTotal: number;
+  companionForcedOpenRate?: number;
+}
+
+function toFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function quantile(values: number[], percentile: number): number | undefined {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = (sorted.length - 1) * percentile;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) {
+    return sorted[lower];
+  }
+
+  const weight = index - lower;
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * weight;
+}
+
+function summarizeLag(values: Array<number | undefined>): { p50?: number; p95?: number } {
+  const finite = values.filter((value): value is number => typeof value === 'number');
+  return {
+    p50: quantile(finite, 0.5),
+    p95: quantile(finite, 0.95),
+  };
+}
+
+function formatRate(value: number | undefined): string {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+
+  return value.toFixed(4);
+}
+
+function formatLag(value: number | undefined): string {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+
+  return `${Math.round(value)}`;
+}
+
+function summarizeRecentMetrics(metrics: MetricRecord[], limit: number): RecentMetricsSummary {
+  const recent = metrics.slice(0, Math.max(0, limit));
+  const lagEdit = summarizeLag(
+    recent.map((metric) => toFiniteNumber(metric.firstMeaningfulEditLagMs)),
+  );
+  const lagRun = summarizeLag(recent.map((metric) => toFiniteNumber(metric.firstRunLagMs)));
+  const lagAction = summarizeLag(recent.map((metric) => toFiniteNumber(metric.firstActionLagMs)));
+
+  const promptTotal = recent.reduce(
+    (sum, metric) => sum + (toFiniteNumber(metric.companionPromptImpressions) ?? 0),
+    0,
+  );
+  const forcedOpenTotal = recent.reduce(
+    (sum, metric) => sum + (toFiniteNumber(metric.companionForcedOpenDetailsClicks) ?? 0),
+    0,
+  );
+  const nudgeTotal = recent.reduce(
+    (sum, metric) => sum + (toFiniteNumber(metric.companionNudgeImpressions) ?? 0),
+    0,
+  );
+
+  return {
+    sessions: recent.length,
+    firstMeaningfulEditLagP50Ms: lagEdit.p50,
+    firstMeaningfulEditLagP95Ms: lagEdit.p95,
+    firstRunLagP50Ms: lagRun.p50,
+    firstRunLagP95Ms: lagRun.p95,
+    firstActionLagP50Ms: lagAction.p50,
+    firstActionLagP95Ms: lagAction.p95,
+    companionPromptImpressionsTotal: promptTotal,
+    companionForcedOpenDetailsClicksTotal: forcedOpenTotal,
+    companionNudgeImpressionsTotal: nudgeTotal,
+    companionForcedOpenRate: promptTotal > 0 ? forcedOpenTotal / promptTotal : undefined,
+  };
+}
+
+export function buildDiagnosticsText(input: DiagnosticsInput): string {
+  const metricSummary = summarizeRecentMetrics(input.recentMetrics, 10);
+  const generatedAtIso = new Date(input.generatedAt).toISOString();
+
+  const lines = [
+    'TaCoS Diagnostics (Safe Bundle)',
+    `generatedAt: ${generatedAtIso}`,
+    `extensionVersion: ${input.extensionVersion}`,
+    `vscodeVersion: ${input.vscodeVersion}`,
+    `workspaceTrust: ${input.workspaceTrusted ? 'trusted' : 'restricted'}`,
+    `summaryProvider: ${input.summaryProvider}`,
+    `uiSurface: ${input.uiSurface}`,
+    `companionRuntimeMode: ${input.companionRuntimeMode}`,
+    `metricsEnabled: ${input.metricsEnabled ? 'true' : 'false'}`,
+    '',
+    'recentMetrics(last10):',
+    `sessions: ${metricSummary.sessions}`,
+    `firstMeaningfulEditLagMs.p50: ${formatLag(metricSummary.firstMeaningfulEditLagP50Ms)}`,
+    `firstMeaningfulEditLagMs.p95: ${formatLag(metricSummary.firstMeaningfulEditLagP95Ms)}`,
+    `firstRunLagMs.p50: ${formatLag(metricSummary.firstRunLagP50Ms)}`,
+    `firstRunLagMs.p95: ${formatLag(metricSummary.firstRunLagP95Ms)}`,
+    `firstActionLagMs.p50: ${formatLag(metricSummary.firstActionLagP50Ms)}`,
+    `firstActionLagMs.p95: ${formatLag(metricSummary.firstActionLagP95Ms)}`,
+    `companionPromptImpressions.total: ${metricSummary.companionPromptImpressionsTotal}`,
+    `companionForcedOpenDetailsClicks.total: ${metricSummary.companionForcedOpenDetailsClicksTotal}`,
+    `companionNudgeImpressions.total: ${metricSummary.companionNudgeImpressionsTotal}`,
+    `companionForcedOpenRate: ${formatRate(metricSummary.companionForcedOpenRate)}`,
+  ];
+
+  return `${lines.join('\n')}\n`;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,6 +14,7 @@ import {
 } from './activityPersistence';
 import { checkpointStorageKey, sanitizeCheckpointNote } from './checkpoint';
 import { resolveCodexOpenCommandCandidates } from './codexInterop';
+import { buildDiagnosticsText } from './diagnostics';
 import {
   captureEditLocation,
   decideEditActivity,
@@ -619,6 +620,9 @@ export function activate(context: vscode.ExtensionContext): void {
       void vscode.window.showInformationMessage(
         `TaCoS: exported metrics to ${jsonPath} and ${csvPath}.`,
       );
+    }),
+    vscode.commands.registerCommand('tacos.copyDiagnostics', async () => {
+      await copyDiagnosticsBundle(context);
     }),
   );
 
@@ -6199,6 +6203,30 @@ async function persistActivity(context: vscode.ExtensionContext): Promise<void> 
   const storageKey = scopedActivityStorageKey(context, workspaceRoot);
   await context.workspaceState.update(storageKey, persisted);
   await touchWorkspaceActivity(context, workspaceRoot);
+}
+
+function extensionVersion(): string {
+  const extension = vscode.extensions.getExtension('jkordish.vscode-tacos');
+  const version = extension?.packageJSON?.version;
+  return typeof version === 'string' && version.trim() ? version.trim() : 'unknown';
+}
+
+async function copyDiagnosticsBundle(context: vscode.ExtensionContext): Promise<void> {
+  const config = getConfig();
+  const metrics = context.workspaceState.get<MetricRecord[]>(KEY_METRIC_HISTORY, []);
+  const diagnostics = buildDiagnosticsText({
+    generatedAt: Date.now(),
+    extensionVersion: extensionVersion(),
+    vscodeVersion: vscode.version,
+    workspaceTrusted: vscode.workspace.isTrusted,
+    summaryProvider: config.summaryProvider,
+    uiSurface: config.uiSurface,
+    companionRuntimeMode: resolveCompanionRuntimeMode(config),
+    metricsEnabled: config.metricsEnabled,
+    recentMetrics: metrics,
+  });
+  await vscode.env.clipboard.writeText(diagnostics);
+  void vscode.window.showInformationMessage('TaCoS: diagnostics copied to clipboard.');
 }
 
 async function maybeFinalizeMetric(context: vscode.ExtensionContext): Promise<void> {

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -1,0 +1,79 @@
+import { buildDiagnosticsText } from '../src/diagnostics';
+import type { MetricRecord } from '../src/types';
+
+function buildMetric(overrides: Partial<MetricRecord> = {}): MetricRecord {
+  return {
+    startedAt: 1_700_000_000_000,
+    workspaceRoot: '/Users/example/private-project',
+    trigger: 'focus',
+    uiSurface: 'notification',
+    firstMeaningfulEditLagMs: 100_000,
+    firstRunLagMs: 220_000,
+    firstActionLagMs: 140_000,
+    companionPromptImpressions: 1,
+    companionForcedOpenDetailsClicks: 0,
+    companionNudgeImpressions: 1,
+    ...overrides,
+  };
+}
+
+describe('buildDiagnosticsText', () => {
+  it('includes required safe diagnostics metadata and aggregated metrics', () => {
+    const diagnostics = buildDiagnosticsText({
+      generatedAt: Date.UTC(2026, 1, 27, 18, 0, 0),
+      extensionVersion: '0.2.1',
+      vscodeVersion: '1.99.0',
+      workspaceTrusted: true,
+      summaryProvider: 'local',
+      uiSurface: 'statusbar',
+      companionRuntimeMode: 'active',
+      metricsEnabled: true,
+      recentMetrics: [
+        buildMetric({
+          firstMeaningfulEditLagMs: 120_000,
+          firstRunLagMs: 300_000,
+          firstActionLagMs: 180_000,
+          companionPromptImpressions: 2,
+          companionForcedOpenDetailsClicks: 1,
+          companionNudgeImpressions: 1,
+        }),
+        buildMetric({
+          firstMeaningfulEditLagMs: 90_000,
+          firstRunLagMs: 240_000,
+          firstActionLagMs: 130_000,
+          companionPromptImpressions: 0,
+          companionForcedOpenDetailsClicks: 0,
+          companionNudgeImpressions: 2,
+        }),
+      ],
+    });
+
+    expect(diagnostics).toContain('extensionVersion: 0.2.1');
+    expect(diagnostics).toContain('vscodeVersion: 1.99.0');
+    expect(diagnostics).toContain('workspaceTrust: trusted');
+    expect(diagnostics).toContain('summaryProvider: local');
+    expect(diagnostics).toContain('sessions: 2');
+    expect(diagnostics).toContain('companionPromptImpressions.total: 2');
+    expect(diagnostics).toContain('companionForcedOpenDetailsClicks.total: 1');
+    expect(diagnostics).toContain('companionNudgeImpressions.total: 3');
+    expect(diagnostics).toContain('companionForcedOpenRate: 0.5000');
+  });
+
+  it('omits workspace paths from diagnostics output', () => {
+    const diagnostics = buildDiagnosticsText({
+      generatedAt: Date.now(),
+      extensionVersion: '0.2.1',
+      vscodeVersion: '1.99.0',
+      workspaceTrusted: false,
+      summaryProvider: 'openai',
+      uiSurface: 'notification',
+      companionRuntimeMode: 'restricted',
+      metricsEnabled: true,
+      recentMetrics: [buildMetric({ workspaceRoot: '/Users/real/secret-workspace' })],
+    });
+
+    expect(diagnostics).not.toContain('/Users/real/secret-workspace');
+    expect(diagnostics).toContain('workspaceTrust: restricted');
+    expect(diagnostics).toContain('summaryProvider: openai');
+  });
+});


### PR DESCRIPTION
## Summary
Implements #80 by establishing a concrete, privacy-safe feedback loop:

- GitHub issue templates for bug/UX/metrics sharing
- a `TaCoS: Copy Diagnostics` command for safe, reproducible reporting

## What Changed
- added issue templates under `.github/ISSUE_TEMPLATE/`:
  - `bug_report.yml`
  - `ux_feedback.yml`
  - `metrics_share.yml`
  - `config.yml` to disable blank issues and point to privacy docs
- added diagnostics module `src/diagnostics.ts` to build a privacy-safe diagnostics bundle
  - includes extension version, VS Code version, trust mode, provider mode, ui surface
  - includes safe aggregate summary for the most recent local metrics (last 10)
  - intentionally excludes raw workspace paths and raw terminal content
- added `TaCoS: Copy Diagnostics` command wiring:
  - `package.json` activation + command contribution
  - command registration in `src/extension.ts`
  - README command list update
- added unit tests in `test/diagnostics.test.ts`
  - verifies required diagnostics fields
  - verifies workspace paths are not leaked

## Validation
- `npm run compile`
- `npm test -- diagnostics`
- `npm run format:check`
- `npm run test:integration`

## Tracking
- Refs #80
- Refs #72
