### PR TITLE
Roadmap: v0.3.0 rubric + candidate issues (#81)

### DIFF
--- a/docs/roadmap-0.3.0.md
+++ b/docs/roadmap-0.3.0.md
@@ -1,0 +1,41 @@
+# TaCoS Roadmap v0.3.0
+
+This document defines how `v0.3.0` scope is selected and tracks the current candidate issue set.
+
+## Triage Rubric
+
+Score each candidate 1-5 for the dimensions below.
+
+| Dimension | 1 (low) | 3 (medium) | 5 (high) |
+| --- | --- | --- | --- |
+| ROI | Limited adoption or quality gain | Noticeable improvement for active users | Clear multiplier on adoption, trust, or reliability |
+| User value | Nice-to-have | Solves a recurring pain point | Removes a top recurring blocker |
+| Safety impact | Neutral | Improves one safety/trust surface | Materially improves trust/privacy/safety guarantees |
+| Complexity | Small isolated change | Multi-file change with moderate coupling | Broad refactor or multi-surface rollout |
+| Risk | Low regression risk | Moderate behavior regression risk | High risk or hard rollback |
+
+Priority heuristic:
+
+- Prefer items with high `ROI + user value + safety impact`.
+- De-prioritize items with high `complexity + risk` unless they unblock a major outcome.
+
+## Explicit Won't-Do List (For v0.3.0)
+
+- Telemetry upload or external analytics services.
+- Expanding TaCoS into non-VS Code product surfaces.
+- New restore actions that bypass existing trust/safety gates.
+- Marketplace/branding overhaul unrelated to product behavior.
+
+## Candidate Issue Set
+
+| Issue | Scope | Labels | Why it made the cut |
+| --- | --- | --- | --- |
+| #90 | Guided first-run setup checklist | `v0.3.0`, `roi:high`, `risk:medium` | Direct adoption and onboarding clarity impact |
+| #91 | Selective restore presets + dry-run plan | `v0.3.0`, `roi:high`, `risk:medium` | Improves confidence and usability of restore workflows |
+| #92 | In-extension metrics baseline snapshot command | `v0.3.0`, `roi:medium`, `risk:low` | Makes evidence-based iteration easier with low implementation risk |
+| #93 | Companion nudge explainability | `v0.3.0`, `roi:medium`, `risk:low` | Improves trust and reduces perceived nudge noise |
+
+## Notes
+
+- Every issue in this set includes explicit acceptance criteria in the issue body.
+- Scope remains intentionally small enough to keep `v0.3.0` executable.


### PR DESCRIPTION
## Summary
Implements #81 by formalizing `v0.3.0` scope selection and creating a labeled candidate issue set with explicit acceptance criteria.

## What Changed
- added `docs/roadmap-0.3.0.md` with:
  - triage rubric across ROI, user value, safety impact, complexity, and risk
  - prioritization heuristic
  - explicit "won't do" list for `v0.3.0`
  - current candidate issue table
- created candidate `v0.3.0` issues with acceptance criteria:
  - #90 `v0.3.0: guided first-run setup checklist`
  - #91 `v0.3.0: selective restore presets + dry-run plan`
  - #92 `v0.3.0: in-extension metrics baseline snapshot command`
  - #93 `v0.3.0: companion nudge explainability`
- added roadmap labels to support triage:
  - `v0.3.0`
  - `roi:high`, `roi:medium`, `roi:low`
  - `risk:low`, `risk:medium`, `risk:high`

## Validation
- `npm run format:check`

## Tracking
- Refs #81
- Refs #72
