### PR TITLE
feat: add in-extension metrics baseline snapshot command (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ TaCoS is built around five non-negotiable principles:
 - `TaCoS: Set OpenAI API Key`
 - `TaCoS: Clear OpenAI API Key`
 - `TaCoS: Export Local Metrics`
+- `TaCoS: Copy Metrics Baseline Snapshot`
 - `TaCoS: Copy Diagnostics`
 
 ### Codex / ChatGPT Interop
@@ -118,6 +119,8 @@ Run `TaCoS: Export Local Metrics` to write:
 
 - `.tacos/metrics.json` (raw session records)
 - `.tacos/metrics.csv` (dashboard-friendly fields + derived rates)
+
+Run `TaCoS: Copy Metrics Baseline Snapshot` to copy a markdown baseline report (lag p50/p95, prompt/nudge/forced-open rates, dogfooding gate status) for issue comments or `docs/metrics-baseline.md`.
 
 Docs:
 

--- a/docs/metrics-baseline.md
+++ b/docs/metrics-baseline.md
@@ -11,15 +11,16 @@ Before marking the epic gate complete:
 
 ## How To Generate Baseline Summary
 
-1. Run `TaCoS: Export Local Metrics` in VS Code.
-2. From repo root, run:
+1. Run `TaCoS: Copy Metrics Baseline Snapshot` in VS Code.
+2. Paste clipboard output into the "Current Baseline Snapshot" section below.
+3. Optionally export raw files for deeper analysis with `TaCoS: Export Local Metrics`.
+4. Optional CLI summary (from repo root):
 
 ```bash
 npm run metrics:summary -- .tacos/metrics.csv
 ```
 
-3. Paste the generated markdown snapshot into the "Current Baseline Snapshot" section below.
-4. Update the date and notes.
+5. Update the date and notes.
 
 ## Current Baseline Snapshot
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -10,6 +10,19 @@ TaCoS metrics are local-only. No telemetry upload or external analytics pipeline
 - `.tacos/metrics.json` (raw local records)
 - `.tacos/metrics.csv` (dashboard-friendly CSV)
 
+## Copy Baseline Snapshot
+
+1. Open Command Palette.
+2. Run `TaCoS: Copy Metrics Baseline Snapshot`.
+3. Paste the markdown snapshot into `docs/metrics-baseline.md` or an issue comment.
+
+The copied snapshot includes:
+- lag p50/p95 for `firstMeaningfulEditLagMs`, `firstRunLagMs`, and `firstActionLagMs`
+- prompt/nudge/forced-open totals and rates
+- dogfooding gate status (`>=30` sessions and `>=3` workspaces)
+
+The snapshot is aggregate-only and excludes raw workspace paths.
+
 ## CSV Data Dictionary
 
 | Column | Type | Description |

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "onCommand:tacos.toggleEnabled",
     "onCommand:tacos.pauseUntilRestart",
     "onCommand:tacos.exportMetrics",
+    "onCommand:tacos.copyMetricsBaselineSnapshot",
     "onCommand:tacos.copyDiagnostics",
     "onCommand:tacos.addVisitedUrl",
     "onCommand:tacos.addCheckpointNote",
@@ -167,6 +168,10 @@
       {
         "command": "tacos.exportMetrics",
         "title": "TaCoS: Export Local Metrics"
+      },
+      {
+        "command": "tacos.copyMetricsBaselineSnapshot",
+        "title": "TaCoS: Copy Metrics Baseline Snapshot"
       },
       {
         "command": "tacos.copyDiagnostics",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { isSummaryLinkEvidenceGrounded } from './evidenceSafety';
 import { collectGit, parsePorcelainPaths } from './git';
 import { tryGenerateOpenAiSummary } from './llm';
 import {
+  buildMetricsBaselineSnapshotMarkdown,
   buildMetricsCsv,
   hasAnyRecordedMetric,
   pruneMetricsForWorkspace,
@@ -628,6 +629,9 @@ export function activate(context: vscode.ExtensionContext): void {
       void vscode.window.showInformationMessage(
         `TaCoS: exported metrics to ${jsonPath} and ${csvPath}.`,
       );
+    }),
+    vscode.commands.registerCommand('tacos.copyMetricsBaselineSnapshot', async () => {
+      await copyMetricsBaselineSnapshot(context);
     }),
     vscode.commands.registerCommand('tacos.copyDiagnostics', async () => {
       await copyDiagnosticsBundle(context);
@@ -6568,6 +6572,24 @@ async function copyDiagnosticsBundle(context: vscode.ExtensionContext): Promise<
   });
   await vscode.env.clipboard.writeText(diagnostics);
   void vscode.window.showInformationMessage('TaCoS: diagnostics copied to clipboard.');
+}
+
+async function copyMetricsBaselineSnapshot(context: vscode.ExtensionContext): Promise<void> {
+  const metrics = context.workspaceState.get<MetricRecord[]>(KEY_METRIC_HISTORY, []);
+  if (metrics.length === 0) {
+    void vscode.window.showInformationMessage(
+      'TaCoS: no local metrics found yet. Run a few sessions first, then try again.',
+    );
+    return;
+  }
+
+  const markdown = buildMetricsBaselineSnapshotMarkdown(metrics, {
+    generatedAt: Date.now(),
+  });
+  await vscode.env.clipboard.writeText(markdown);
+  void vscode.window.showInformationMessage(
+    'TaCoS: metrics baseline snapshot copied to clipboard.',
+  );
 }
 
 async function maybeFinalizeMetric(context: vscode.ExtensionContext): Promise<void> {

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -44,6 +44,129 @@ function toRatio(numerator: number, denominator: number): string {
   return (numerator / denominator).toFixed(4);
 }
 
+function toFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function quantile(values: number[], percentile: number): number | undefined {
+  if (values.length === 0) {
+    return undefined;
+  }
+
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = (sorted.length - 1) * percentile;
+  const lower = Math.floor(index);
+  const upper = Math.ceil(index);
+  if (lower === upper) {
+    return sorted[lower];
+  }
+
+  const weight = index - lower;
+  return sorted[lower] + (sorted[upper] - sorted[lower]) * weight;
+}
+
+function formatMs(value: number | undefined): string {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+
+  return `${Math.round(value)} (${(value / 1000).toFixed(1)}s)`;
+}
+
+function formatNumber(value: number | undefined, digits = 2): string {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 'n/a';
+  }
+
+  return value.toFixed(digits);
+}
+
+interface LagSummary {
+  n: number;
+  p50?: number;
+  p95?: number;
+}
+
+function summarizeLag(metrics: MetricRecord[], lagField: keyof MetricRecord): LagSummary {
+  const values = metrics
+    .map((metric) => toFiniteNumber(metric[lagField]))
+    .filter((value): value is number => typeof value === 'number');
+
+  return {
+    n: values.length,
+    p50: quantile(values, 0.5),
+    p95: quantile(values, 0.95),
+  };
+}
+
+function summarizeTotal(metrics: MetricRecord[], field: keyof MetricRecord): number {
+  return metrics.reduce((sum, metric) => sum + (toFiniteNumber(metric[field]) ?? 0), 0);
+}
+
+export interface MetricsBaselineSnapshotOptions {
+  generatedAt?: number;
+  sourceLabel?: string;
+}
+
+export function buildMetricsBaselineSnapshotMarkdown(
+  metrics: MetricRecord[],
+  options: MetricsBaselineSnapshotOptions = {},
+): string {
+  const generatedAtIso = new Date(options.generatedAt ?? Date.now()).toISOString();
+  const sessions = metrics.length;
+  const workspaceCount = new Set(
+    metrics.map((metric) => metric.workspaceRoot.trim()).filter((workspaceRoot) => workspaceRoot),
+  ).size;
+  const dogfoodingGateMet = sessions >= 30 && workspaceCount >= 3;
+
+  const lagEdit = summarizeLag(metrics, 'firstMeaningfulEditLagMs');
+  const lagRun = summarizeLag(metrics, 'firstRunLagMs');
+  const lagAction = summarizeLag(metrics, 'firstActionLagMs');
+
+  const promptImpressions = summarizeTotal(metrics, 'companionPromptImpressions');
+  const forcedOpenClicks = summarizeTotal(metrics, 'companionForcedOpenDetailsClicks');
+  const nudgeImpressions = summarizeTotal(metrics, 'companionNudgeImpressions');
+  const forcedOpenRate = promptImpressions > 0 ? forcedOpenClicks / promptImpressions : undefined;
+  const promptPerSession = sessions > 0 ? promptImpressions / sessions : undefined;
+  const nudgePerSession = sessions > 0 ? nudgeImpressions / sessions : undefined;
+
+  const lines = [
+    '# TaCoS Metrics Baseline Snapshot',
+    '',
+    `Date: \`${generatedAtIso}\``,
+    `Source: \`${options.sourceLabel ?? 'Local workspace-state metric history'}\``,
+    '',
+    'Status:',
+    `- Dogfooding gate (\`>=30 sessions\` and \`>=3 workspaces\`): ${dogfoodingGateMet ? 'met' : 'not yet met'}`,
+    `- Sessions: ${sessions}`,
+    `- Distinct workspaces: ${workspaceCount}`,
+    '',
+    'Lag summary:',
+    '',
+    '| Metric | n | p50 (ms / s) | p95 (ms / s) |',
+    '| --- | ---: | ---: | ---: |',
+    `| \`firstMeaningfulEditLagMs\` | ${lagEdit.n} | ${formatMs(lagEdit.p50)} | ${formatMs(lagEdit.p95)} |`,
+    `| \`firstRunLagMs\` | ${lagRun.n} | ${formatMs(lagRun.p50)} | ${formatMs(lagRun.p95)} |`,
+    `| \`firstActionLagMs\` | ${lagAction.n} | ${formatMs(lagAction.p50)} | ${formatMs(lagAction.p95)} |`,
+    '',
+    'Prompt and nudge rates:',
+    '',
+    '| Metric | Value |',
+    '| --- | ---: |',
+    `| Prompt impressions (total) | ${promptImpressions} |`,
+    `| Prompt impressions per session | ${formatNumber(promptPerSession)} |`,
+    `| Forced-open details clicks (total) | ${forcedOpenClicks} |`,
+    `| Forced-open rate (\`forced/prompt\`) | ${formatNumber(forcedOpenRate, 4)} |`,
+    `| Nudge impressions (total) | ${nudgeImpressions} |`,
+    `| Nudge impressions per session | ${formatNumber(nudgePerSession)} |`,
+    '',
+    'Notes:',
+    '- Snapshot contains aggregate-only values and excludes raw workspace paths.',
+  ];
+
+  return `${lines.join('\n')}\n`;
+}
+
 export function hasAnyRecordedMetric(metric: MetricRecord): boolean {
   if (!Number.isFinite(metric.startedAt) || !metric.workspaceRoot.trim()) {
     return false;

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildMetricsBaselineSnapshotMarkdown,
   buildMetricsCsv,
   hasAnyRecordedMetric,
   pruneMetricsForWorkspace,
@@ -105,5 +106,84 @@ describe('workspace metric helpers', () => {
         trigger: 'cached',
       },
     ]);
+  });
+});
+
+describe('buildMetricsBaselineSnapshotMarkdown', () => {
+  it('includes lag quantiles, rates, and dogfooding gate status', () => {
+    const markdown = buildMetricsBaselineSnapshotMarkdown(
+      [
+        {
+          startedAt: Date.UTC(2026, 1, 1, 10, 0, 0),
+          workspaceRoot: '/workspace/a',
+          trigger: 'focus',
+          firstMeaningfulEditLagMs: 1000,
+          firstRunLagMs: 2000,
+          firstActionLagMs: 1500,
+          companionPromptImpressions: 2,
+          companionForcedOpenDetailsClicks: 1,
+          companionNudgeImpressions: 1,
+        },
+        {
+          startedAt: Date.UTC(2026, 1, 1, 10, 5, 0),
+          workspaceRoot: '/workspace/b',
+          trigger: 'manual',
+          firstMeaningfulEditLagMs: 2000,
+          firstRunLagMs: 4000,
+          firstActionLagMs: 2500,
+          companionPromptImpressions: 3,
+          companionForcedOpenDetailsClicks: 1,
+          companionNudgeImpressions: 2,
+        },
+        {
+          startedAt: Date.UTC(2026, 1, 1, 10, 10, 0),
+          workspaceRoot: '/workspace/c',
+          trigger: 'cached',
+          firstMeaningfulEditLagMs: 3000,
+          firstActionLagMs: 3500,
+        },
+      ],
+      { generatedAt: Date.UTC(2026, 1, 1, 12, 0, 0) },
+    );
+
+    expect(markdown).toContain('# TaCoS Metrics Baseline Snapshot');
+    expect(markdown).toContain('Date: `2026-02-01T12:00:00.000Z`');
+    expect(markdown).toContain(
+      'Dogfooding gate (`>=30 sessions` and `>=3 workspaces`): not yet met',
+    );
+    expect(markdown).toContain('| `firstMeaningfulEditLagMs` | 3 | 2000 (2.0s) | 2900 (2.9s) |');
+    expect(markdown).toContain('| `firstRunLagMs` | 2 | 3000 (3.0s) | 3900 (3.9s) |');
+    expect(markdown).toContain('| `firstActionLagMs` | 3 | 2500 (2.5s) | 3400 (3.4s) |');
+    expect(markdown).toContain('| Prompt impressions (total) | 5 |');
+    expect(markdown).toContain('| Prompt impressions per session | 1.67 |');
+    expect(markdown).toContain('| Forced-open details clicks (total) | 2 |');
+    expect(markdown).toContain('| Forced-open rate (`forced/prompt`) | 0.4000 |');
+    expect(markdown).toContain('| Nudge impressions (total) | 3 |');
+    expect(markdown).toContain('| Nudge impressions per session | 1.00 |');
+  });
+
+  it('stays privacy-safe and marks gate as met for qualifying dogfooding sample', () => {
+    const metrics: MetricRecord[] = Array.from({ length: 30 }, (_, index) => ({
+      startedAt: Date.UTC(2026, 1, 10, 9, index, 0),
+      workspaceRoot: `/Users/private/workspace-${index % 3}`,
+      trigger: 'focus',
+      firstMeaningfulEditLagMs: 2000 + index,
+      firstRunLagMs: 4000 + index,
+      firstActionLagMs: 2500 + index,
+      companionPromptImpressions: 1,
+      companionForcedOpenDetailsClicks: index % 2,
+      companionNudgeImpressions: index % 3,
+    }));
+
+    const markdown = buildMetricsBaselineSnapshotMarkdown(metrics, {
+      generatedAt: Date.UTC(2026, 1, 15, 12, 0, 0),
+    });
+
+    expect(markdown).toContain('Dogfooding gate (`>=30 sessions` and `>=3 workspaces`): met');
+    expect(markdown).toContain('- Sessions: 30');
+    expect(markdown).toContain('- Distinct workspaces: 3');
+    expect(markdown).not.toContain('/Users/private/workspace-0');
+    expect(markdown).not.toContain('/Users/private/workspace-1');
+    expect(markdown).not.toContain('/Users/private/workspace-2');
   });
 });


### PR DESCRIPTION
## Summary
- add a new command `TaCoS: Copy Metrics Baseline Snapshot`
- generate a privacy-safe markdown baseline snapshot directly from local metric history
- include p50/p95 lag summaries, prompt/nudge/forced-open rates, and dogfooding gate status (`>=30` sessions and `>=3` workspaces)
- register command activation/contribution metadata and update metrics docs
- add unit tests for markdown snapshot output and privacy safety

## Testing
- npm run format:check
- npm run lint
- npm run compile
- npm test
- npm run test:integration

Closes #92
