### PR TITLE
feat: add companion nudge explainability in panel (#93)

### DIFF
--- a/src/companionNudges.ts
+++ b/src/companionNudges.ts
@@ -23,6 +23,10 @@ export interface CompanionNudgeDecision {
   nextEligibleAt?: number;
 }
 
+interface SuppressionTextOptions {
+  formatTimestamp?: (value: number) => string;
+}
+
 interface CompanionNudgeInput {
   summary: ResumeSummary;
   provider: SummaryProvider;
@@ -131,6 +135,62 @@ export function chooseCompanionNudges(input: CompanionNudgeInput): CompanionNudg
 
   const [primary, secondary] = scored;
   return { primary, secondary };
+}
+
+export function describeCompanionNudgeReason(nudge: CompanionNudge): string {
+  if (nudge.id === 'fix-failing-command') {
+    return 'A recent failing command was detected for this context, so TaCoS prioritizes remediation.';
+  }
+
+  if (nudge.id === 'branch-switch') {
+    return 'TaCoS detected a branch switch between your last and current context.';
+  }
+
+  if (nudge.id === 'resume-next-step') {
+    return 'TaCoS found a saved next step and surfaced it as the fastest way to resume.';
+  }
+
+  if (nudge.id === 'refresh-guidance') {
+    return 'No concrete next step was available, so TaCoS suggests regenerating guidance.';
+  }
+
+  return 'TaCoS selected this nudge from local context signals.';
+}
+
+export function describeCompanionNudgeSuppression(
+  decision: CompanionNudgeDecision | undefined,
+  options: SuppressionTextOptions = {},
+): string {
+  if (!decision?.suppressedReason) {
+    return '';
+  }
+
+  if (decision.suppressedReason === 'disabled') {
+    return 'Companion nudges are disabled in settings.';
+  }
+
+  if (decision.suppressedReason === 'inactive-mode') {
+    return 'Nudges are hidden while companion mode is paused or restricted.';
+  }
+
+  if (decision.suppressedReason === 'quiet-hours') {
+    return 'Nudges are currently in your configured quiet hours window.';
+  }
+
+  if (decision.suppressedReason === 'cooldown') {
+    if (!decision.nextEligibleAt) {
+      return 'Nudges are cooling down before the next reminder.';
+    }
+
+    const formatter = options.formatTimestamp ?? ((value: number) => new Date(value).toISOString());
+    return `Nudges are cooling down until ${formatter(decision.nextEligibleAt)}.`;
+  }
+
+  if (decision.suppressedReason === 'no-candidate') {
+    return 'No high-confidence nudge is available for this context yet.';
+  }
+
+  return '';
 }
 
 export const __test__ = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,12 @@ import { promisify } from 'node:util';
 import * as vscode from 'vscode';
 import MarkdownIt from 'markdown-it';
 import { buildAiPayloadPreviewMarkdown } from './aiPayloadPreview';
-import { type CompanionNudgeDecision, chooseCompanionNudges } from './companionNudges';
+import {
+  chooseCompanionNudges,
+  describeCompanionNudgeReason,
+  describeCompanionNudgeSuppression,
+  type CompanionNudgeDecision,
+} from './companionNudges';
 import {
   persistTerminalCommandForStorage,
   sanitizeActivityForPersistence,
@@ -1657,28 +1662,6 @@ function nudgeActionLabel(action: string): string {
   return 'Take action';
 }
 
-function describeNudgeSuppression(decision: CompanionNudgeDecision | undefined): string {
-  if (!decision?.suppressedReason || decision.suppressedReason === 'no-candidate') {
-    return '';
-  }
-
-  if (decision.suppressedReason === 'disabled') {
-    return 'Companion nudges are disabled in settings.';
-  }
-  if (decision.suppressedReason === 'inactive-mode') {
-    return 'Nudges are hidden while companion mode is paused or restricted.';
-  }
-  if (decision.suppressedReason === 'quiet-hours') {
-    return 'Nudges are currently in your configured quiet hours window.';
-  }
-  if (decision.suppressedReason === 'cooldown') {
-    return decision.nextEligibleAt
-      ? `Nudges are cooling down until ${formatTimestamp(decision.nextEligibleAt)}.`
-      : 'Nudges are cooling down before the next reminder.';
-  }
-  return '';
-}
-
 function summarizeForStatusBar(raw: string, maxChars = 44): string {
   const compact = raw.replace(/\s+/g, ' ').trim();
   if (!compact) {
@@ -2519,7 +2502,29 @@ function renderWebview(
       : undefined;
   const primaryNudge = activeNudgeDecision?.primary;
   const secondaryNudge = activeNudgeDecision?.secondary;
-  const nudgeSuppressionLabel = describeNudgeSuppression(activeNudgeDecision);
+  const nudgeSuppressionLabel = describeCompanionNudgeSuppression(activeNudgeDecision, {
+    formatTimestamp,
+  });
+  const primaryNudgeReason = primaryNudge ? describeCompanionNudgeReason(primaryNudge) : '';
+  const secondaryNudgeReason = secondaryNudge ? describeCompanionNudgeReason(secondaryNudge) : '';
+  const nudgeExplainability =
+    primaryNudge || nudgeSuppressionLabel
+      ? `<details>
+        <summary><strong>${primaryNudge ? 'Why this nudge?' : 'Why no nudge right now?'}</strong></summary>
+        ${
+          primaryNudge
+            ? `<ul class="compact-list">
+            <li>${escapeHtml(primaryNudgeReason)}</li>
+            ${
+              secondaryNudge
+                ? `<li>Secondary action rationale: ${escapeHtml(secondaryNudgeReason)}</li>`
+                : ''
+            }
+          </ul>`
+            : `<p class="muted">${escapeHtml(nudgeSuppressionLabel)}</p>`
+        }
+      </details>`
+      : '';
   const switchedBranches =
     Boolean(summary.currentBranch) &&
     Boolean(summary.previousBranch) &&
@@ -2812,6 +2817,7 @@ function renderWebview(
           ? `<p class="muted">${escapeHtml(nudgeSuppressionLabel)}</p>`
           : ''
       }
+      ${nudgeExplainability}
     </div>`
       : '';
 

--- a/test/companionNudges.test.ts
+++ b/test/companionNudges.test.ts
@@ -1,4 +1,9 @@
-import { __test__, chooseCompanionNudges } from '../src/companionNudges';
+import {
+  __test__,
+  chooseCompanionNudges,
+  describeCompanionNudgeReason,
+  describeCompanionNudgeSuppression,
+} from '../src/companionNudges';
 import type { ResumeSummary } from '../src/types';
 
 function buildSummary(overrides: Partial<ResumeSummary> = {}): ResumeSummary {
@@ -170,5 +175,66 @@ describe('quiet hour parser', () => {
 
     expect(__test__.isInQuietHours(januaryMorningLocal, '09:00-12:00')).toBe(true);
     expect(__test__.isInQuietHours(januaryLateLocal, '09:00-12:00')).toBe(false);
+  });
+});
+
+describe('nudge explainability helpers', () => {
+  it.each([
+    [
+      'fix-failing-command',
+      'A recent failing command was detected for this context, so TaCoS prioritizes remediation.',
+    ],
+    ['branch-switch', 'TaCoS detected a branch switch between your last and current context.'],
+    [
+      'resume-next-step',
+      'TaCoS found a saved next step and surfaced it as the fastest way to resume.',
+    ],
+    [
+      'refresh-guidance',
+      'No concrete next step was available, so TaCoS suggests regenerating guidance.',
+    ],
+  ] as const)('maps nudge reason text for %s', (id, expected) => {
+    const decision = chooseCompanionNudges(
+      buildInput({
+        aggressiveness: id === 'refresh-guidance' ? 'high' : 'balanced',
+        summary: buildSummary({
+          lastFailingCommand: id === 'fix-failing-command' ? 'npm test' : undefined,
+          currentBranch: id === 'branch-switch' ? 'feature/a' : undefined,
+          previousBranch: id === 'branch-switch' ? 'main' : undefined,
+          nextSteps: id === 'refresh-guidance' ? [] : ['Do thing'],
+        }),
+      }),
+    );
+
+    const nudge =
+      decision.primary?.id === id
+        ? decision.primary
+        : decision.secondary?.id === id
+          ? decision.secondary
+          : undefined;
+    expect(nudge).toBeDefined();
+    expect(describeCompanionNudgeReason(nudge!)).toBe(expected);
+  });
+
+  it('renders suppression reasons including no-candidate and cooldown timestamp', () => {
+    const disabled = describeCompanionNudgeSuppression({ suppressedReason: 'disabled' });
+    const inactive = describeCompanionNudgeSuppression({ suppressedReason: 'inactive-mode' });
+    const quiet = describeCompanionNudgeSuppression({ suppressedReason: 'quiet-hours' });
+    const noCandidate = describeCompanionNudgeSuppression({ suppressedReason: 'no-candidate' });
+    const cooldown = describeCompanionNudgeSuppression(
+      {
+        suppressedReason: 'cooldown',
+        nextEligibleAt: 1_700_000_000_000,
+      },
+      {
+        formatTimestamp: () => 'soon',
+      },
+    );
+
+    expect(disabled).toBe('Companion nudges are disabled in settings.');
+    expect(inactive).toBe('Nudges are hidden while companion mode is paused or restricted.');
+    expect(quiet).toBe('Nudges are currently in your configured quiet hours window.');
+    expect(noCandidate).toBe('No high-confidence nudge is available for this context yet.');
+    expect(cooldown).toBe('Nudges are cooling down until soon.');
   });
 });


### PR DESCRIPTION
## Summary
- add explainability helpers for companion nudges:
  - deterministic reason text for each nudge type
  - deterministic suppression reason text (including `no-candidate`)
- add compact explainability affordance in the panel:
  - "Why this nudge?" when a nudge is shown
  - "Why no nudge right now?" when nudges are suppressed
- show suppression reasons for cooldown, quiet-hours, inactive mode, disabled mode, and no-candidate
- add tests for explainability text mapping and suppression reason rendering

## Testing
- npm run format:check
- npm run lint
- npm run compile
- npm test
- npm run test:integration

Closes #93
