### PR TITLE
docs: close out v0.3 metrics snapshot + release checklist

### DIFF
--- a/docs/metrics-baseline.md
+++ b/docs/metrics-baseline.md
@@ -1,6 +1,6 @@
 # Metrics Baseline (Dogfooding)
 
-This document records local dogfooding metrics used to evaluate TaCoS stabilization progress for `0.2.x`.
+This document records local dogfooding metrics used to evaluate TaCoS stabilization and adoption progress.
 
 ## Minimum Sample Gate
 
@@ -24,32 +24,33 @@ npm run metrics:summary -- .tacos/metrics.csv
 
 ## Current Baseline Snapshot
 
-Date: `TBD`
-Source CSV: `.tacos/metrics.csv`
+Date: `2026-02-27`
+Source: `Repository-local snapshot (no .tacos/metrics.csv present in this checkout)`
 
 Status:
-- Dogfooding gate met: `TBD`
-- Sessions: `TBD`
-- Distinct workspaces: `TBD`
+- Dogfooding gate met: `no`
+- Sessions: `0`
+- Distinct workspaces: `0`
 
 Lag summary (ms):
 
 | Metric | n | p50 | p95 |
 | --- | ---: | ---: | ---: |
-| `firstMeaningfulEditLagMs` | TBD | TBD | TBD |
-| `firstRunLagMs` | TBD | TBD | TBD |
-| `firstActionLagMs` | TBD | TBD | TBD |
+| `firstMeaningfulEditLagMs` | 0 | n/a | n/a |
+| `firstRunLagMs` | 0 | n/a | n/a |
+| `firstActionLagMs` | 0 | n/a | n/a |
 
 Prompt and nudge rates:
 
 | Metric | Value |
 | --- | ---: |
-| Prompt impressions (total) | TBD |
-| Forced-open details clicks (total) | TBD |
-| Forced-open rate (`forced/prompt`) | TBD |
-| Nudge impressions (total) | TBD |
-| Nudge impressions per session | TBD |
+| Prompt impressions (total) | 0 |
+| Forced-open details clicks (total) | 0 |
+| Forced-open rate (`forced/prompt`) | n/a |
+| Nudge impressions (total) | 0 |
+| Nudge impressions per session | n/a |
 
 Notes:
-- Replace all `TBD` values with the latest local export summary before closing epic `#72`.
+- This is a valid post-implementation baseline snapshot, but it does not meet the dogfooding gate yet.
+- Replace this section with fresh output from `TaCoS: Copy Metrics Baseline Snapshot` once local sessions are recorded.
 - Keep this document local-context safe (no raw workspace paths in shared copies).

--- a/docs/release-0.3.0-checklist.md
+++ b/docs/release-0.3.0-checklist.md
@@ -1,0 +1,48 @@
+# Release 0.3.0 Checklist
+
+Use this checklist to prepare, tag, and publish the `v0.3.0` release.
+
+## 1) Scope Lock
+
+- [ ] Confirm only `v0.3.0` roadmap items are included.
+- [ ] Confirm post-`v0.3.0` ideas are moved to new issues (not bundled into this release).
+
+## 2) Feature Track Completion
+
+- [x] #90 guided first-run setup checklist
+- [x] #91 selective restore presets + dry-run plan
+- [x] #92 in-extension metrics baseline snapshot command
+- [x] #93 companion nudge explainability
+
+## 3) Versioning + Changelog
+
+- [ ] Update `package.json` version to `0.3.0`.
+- [ ] Add `v0.3.0` section to `CHANGELOG.md` with links to included PRs/issues.
+- [ ] Confirm release notes summarize adoption/confidence improvements and trust boundaries.
+
+## 4) Verify Gates
+
+- [ ] `npm run verify`
+- [ ] Confirm CI checks are green on the release prep branch.
+- [ ] Smoke-check key commands in VS Code:
+  - `TaCoS: Run Setup Checklist`
+  - `TaCoS: Restore Working Set`
+  - `TaCoS: Copy Metrics Baseline Snapshot`
+  - `TaCoS: Show Last Summary`
+
+## 5) Docs + Metrics Snapshot
+
+- [x] Publish a post-implementation baseline snapshot in `docs/metrics-baseline.md`.
+- [ ] If available, refresh snapshot with non-empty local dogfooding sample before release tag.
+- [ ] Confirm `docs/metrics.md` and `docs/quickstart.md` match shipped command behavior.
+
+## 6) Tag + Publish
+
+- [ ] Merge release prep PR to `main`.
+- [ ] Create and push tag `v0.3.0`.
+- [ ] Publish GitHub release notes and artifact.
+
+## 7) Post-Release Observation
+
+- [ ] Track regressions for `v0.3.0` rollout window and record any P0/P1 incidents.
+- [ ] Link follow-up fixes to the release notes if a `v0.3.1` patch is required.


### PR DESCRIPTION
## Summary
- publish a concrete post-implementation baseline snapshot in `docs/metrics-baseline.md` (current repo-local state)
- add `docs/release-0.3.0-checklist.md` to prepare version/tag/release workflow
- keep snapshot output privacy-safe and explicit about gate status

## Validation
- npm run format:check
- npm run compile

Related: #98
