### PR TITLE
chore(release): prep v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
+- No notable changes yet.
+
+## [0.5.0] - 2026-02-27
+
+### Added
+
 - Security-first sanitization and trust controls for notes/scratchpad AI flows:
   - Redaction engine v2 with mode-aware sanitization and structured redaction reporting.
   - Strict AI-boundary sanitizer with fail-closed high-risk detection across provider send paths.

--- a/docs/release-0.5.0-checklist.md
+++ b/docs/release-0.5.0-checklist.md
@@ -1,0 +1,58 @@
+# Release 0.5.0 Checklist
+
+Use this checklist to prepare, tag, and publish the `v0.5.0` release.
+
+## 1) Scope Lock
+
+- [x] Confirm only `v0.5.0` epic scope is included.
+- [x] Confirm child issues #118-#126 are completed and linked to epic #117.
+- [x] Confirm out-of-scope items remain out of this release (no cloud sync/telemetry upload/secret-manager features).
+
+## 2) Feature Track Completion
+
+- [x] #118 Redaction engine v2: modes + reporting + safe replacements
+- [x] #119 Expand default detectors: common tokens + headers + Windows paths
+- [x] #120 Hardening custom `tacos.redactionPatterns`: bounded, safe, non-footgun
+- [x] #121 Strict AI-boundary sanitizer: high-risk detection + fail-closed gating
+- [x] #122 UX: redaction visibility + `TaCoS: Test Sanitizer` + note-change warnings
+- [x] #123 AI payload preview + consent: include/exclude toggles + redaction report
+- [x] #124 Config: safe-by-default settings for AI inclusion of notes/scratchpad + sanitize mode
+- [x] #125 Metrics: aggregate-only counters for redaction + blocked sends (local export)
+- [x] #126 Tests + docs + issue templates: security-first rollout
+- [x] #117 Epic closure (post-merge)
+
+## 3) Versioning + Changelog
+
+- [x] Update `package.json` version to `0.5.0`.
+- [x] Update `package-lock.json` to `0.5.0` package metadata.
+- [x] Add `v0.5.0` section to `CHANGELOG.md` with security-first rollout highlights.
+- [x] Confirm release notes emphasize trust boundaries and limitations (risk reduction, not guarantee).
+
+## 4) Verify Gates
+
+- [ ] `npm run verify`
+- [ ] Confirm CI checks are green on release prep PR.
+- [ ] Smoke-check key commands in VS Code:
+  - `TaCoS: Test Sanitizer`
+  - `TaCoS: Revoke AI Payload Consent`
+  - `TaCoS: Copy Prompt and Open Codex` (strict sanitize boundary)
+  - `TaCoS: Add Checkpoint Note` and `TaCoS: Append to Scratchpad` (redaction-change UX)
+
+## 5) Docs + Safety Artifacts
+
+- [x] Confirm `docs/privacy-safety.md` reflects fail-closed AI boundary and safe defaults.
+- [x] Confirm `docs/quickstart.md` calls out AI inclusion opt-in for checkpoint/scratchpad.
+- [x] Confirm `docs/metrics.md` includes aggregate-only sanitizer counters.
+- [x] Confirm privacy-safe issue templates exist under `.github/ISSUE_TEMPLATE/`.
+
+## 6) Tag + Publish
+
+- [ ] Merge release prep PR to `main`.
+- [ ] Create and push annotated tag `v0.5.0`.
+- [ ] Confirm GitHub Actions `Release VSIX` workflow succeeds for the `v0.5.0` tag.
+- [ ] Confirm release page has generated notes + attached VSIX artifact.
+
+## 7) Post-Release Observation
+
+- [ ] Watch first 24-48h for sanitizer false-positive/false-negative reports.
+- [ ] Link any follow-up fixes as `v0.5.1` candidates if needed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-tacos",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-tacos",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "markdown-it": "^14.1.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "TaCoS Resume Brief",
   "description": "Auto task-context summaries when you resume work in VS Code.",
   "license": "MIT",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "publisher": "jkordish",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
Release prep for `v0.5.0` after merging the security-first sanitization rollout.

## Included
- Bump extension version to `0.5.0` (`package.json`, `package-lock.json`).
- Cut changelog release section: `## [0.5.0] - 2026-02-27`.
- Add `docs/release-0.5.0-checklist.md` for final verify/tag/publish tracking.

## Validation
- `npm run verify:quick` passed
  - format:check PASS
  - lint PASS
  - compile PASS
  - test PASS (29 suites, 168 tests)

## Context
- Feature delivery PR already merged: #127
- v0.5.0 epic and child issues are complete/closed: #117-#126
