### PR TITLE
v0.6.0: Add local metrics for primary CTA usage/completion and timing class (fixes #156)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -19,6 +19,8 @@ TaCoS metrics are local-only. No telemetry upload or external analytics pipeline
 The copied snapshot includes:
 - lag p50/p95 for `firstMeaningfulEditLagMs`, `firstRunLagMs`, and `firstActionLagMs`
 - prompt/nudge/forced-open totals and rates
+- primary CTA impression/click/completion totals and rates
+- interruption timing class breakdown (`boundary`, `mid-activity`, `unknown`)
 - dogfooding gate status (`>=30` sessions and `>=3` workspaces)
 
 The snapshot is aggregate-only and excludes raw workspace paths.
@@ -34,6 +36,7 @@ The snapshot is aggregate-only and excludes raw workspace paths.
 | `trigger` | enum | Summary trigger (`focus`, `manual`, `cached`). |
 | `uiSurface` | enum | UI surface mode (`statusbar`, `notification`, `silent`). |
 | `interruptionEvent` | integer | `1` when focus-triggered summary used notification prompt mode, else `0`/empty. |
+| `interruptionTimingClass` | enum | Focus-return timing class: `boundary`, `mid-activity`, or `unknown`. |
 | `firstMeaningfulEditLagMs` | integer | Milliseconds from session start to first meaningful edit. |
 | `firstRunLagMs` | integer | Milliseconds from session start to first run/test/debug action. |
 | `firstActionLagMs` | integer | Milliseconds from session start to first meaningful action of any tracked type. |
@@ -42,6 +45,9 @@ The snapshot is aggregate-only and excludes raw workspace paths.
 | `companionForcedOpenDetailsClicks` | integer | Number of "Open details" forced-open clicks from prompt mode. |
 | `companionQuickActionsTaken` | integer | Number of prompt-mode quick actions taken (copy/pause/open flows). |
 | `companionNudgeImpressions` | integer | Number of accepted companion nudge impressions in session. |
+| `companionPrimaryCtaImpressions` | integer | Number of sessions where TaCoS rendered a primary next-action CTA. |
+| `companionPrimaryCtaClicks` | integer | Number of primary CTA clicks taken by the user. |
+| `companionPrimaryCtaCompletions` | integer | Number of primary CTA attempts that completed successfully. |
 | `helpfulnessRating` | integer | Optional local rating (`1`-`5`) from `TaCoS: Rate Summary Helpfulness`. |
 | `pauseActions` | integer | Count of pause actions taken during session. |
 | `snoozeActions` | integer | Count of snooze actions taken during session. |
@@ -49,6 +55,7 @@ The snapshot is aggregate-only and excludes raw workspace paths.
 | `noteCreated` | integer | Count of checkpoint notes created during session. |
 | `noteMarkedDone` | integer | Count of checkpoint notes marked done during session. |
 | `notePinned` | integer | Count of checkpoint notes pinned during session. |
+| `resumePathCompletions` | integer | Count of completed resume-path checklist steps (when feature is enabled). |
 | `resumeWithNote` | integer | `1` if an open checkpoint note was present in the resume context, else `0`. |
 | `scratchpadOpened` | integer | Count of `TaCoS: Open Scratchpad` actions during session. |
 | `scratchpadAppended` | integer | Count of `TaCoS: Append to Scratchpad` actions during session. |
@@ -58,6 +65,8 @@ The snapshot is aggregate-only and excludes raw workspace paths.
 | `aiSendAllowedAfterReviewTotal` | integer | Count of AI sends explicitly approved after payload review. |
 | `companionActionFollowThroughRate` | ratio | Derived as `companionQuickActionsTaken / companionPromptImpressions`. |
 | `companionForcedOpenRate` | ratio | Derived as `companionForcedOpenDetailsClicks / companionPromptImpressions`. |
+| `companionPrimaryCtaClickThroughRate` | ratio | Derived as `companionPrimaryCtaClicks / companionPrimaryCtaImpressions`. |
+| `companionPrimaryCtaCompletionRate` | ratio | Derived as `companionPrimaryCtaCompletions / companionPrimaryCtaClicks`. |
 
 ## Epic #72 Key Fields
 
@@ -69,9 +78,14 @@ Track these explicitly for stabilization/adoption gating:
 - `companionPromptImpressions`
 - `companionForcedOpenDetailsClicks`
 - `companionNudgeImpressions`
+- `companionPrimaryCtaImpressions`
+- `companionPrimaryCtaClicks`
+- `companionPrimaryCtaCompletions`
+- `interruptionTimingClass`
 - `noteCreated`
 - `noteMarkedDone`
 - `notePinned`
+- `resumePathCompletions`
 - `resumeWithNote`
 - `scratchpadOpened`
 - `scratchpadAppended`

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,6 +128,8 @@ const SECRET_OPENAI_API_KEY = 'tacos.openaiApiKey';
 const KEY_METRIC_HISTORY = 'tacos.metricHistory';
 const CHECKPOINT_PROMPT_COOLDOWN_MINUTES = 45;
 const FOCUS_TRIGGER_DEBOUNCE_MS = 1200;
+const INTERRUPTION_TIMING_BOUNDARY_WINDOW_MS = 90_000;
+const INTERRUPTION_TIMING_MID_ACTIVITY_WINDOW_MS = 15_000;
 const MAX_CHECKPOINT_NOTES_PER_SCOPE = 50;
 const CHECKPOINT_WORKSPACE_GLOBAL_SCOPE = 'workspace-global';
 const SCRATCHPAD_PREVIEW_MAX_LINES = 5;
@@ -213,6 +215,8 @@ interface RuntimeState {
   activeRefinementContextHash?: string;
   autoSummaryInFlight: boolean;
   lastAutoFocusTriggerAt: number;
+  lastBoundarySignalAt: number;
+  lastMeaningfulActivityAt: number;
   meaningfulActivitySinceCheckpointPrompt: boolean;
   pauseUntilRestart: boolean;
   snoozeUntil: number;
@@ -329,6 +333,8 @@ export function activate(context: vscode.ExtensionContext): void {
     activeRefinementContextHash: undefined,
     autoSummaryInFlight: false,
     lastAutoFocusTriggerAt: 0,
+    lastBoundarySignalAt: 0,
+    lastMeaningfulActivityAt: 0,
     meaningfulActivitySinceCheckpointPrompt: false,
     pauseUntilRestart: false,
     snoozeUntil: context.workspaceState.get<number>(KEY_SUMMARY_SNOOZE_UNTIL, 0),
@@ -823,6 +829,14 @@ export function activate(context: vscode.ExtensionContext): void {
   );
 
   context.subscriptions.push(
+    vscode.debug.onDidTerminateDebugSession(async () => {
+      markBoundarySignal();
+      markMeaningfulActivity();
+      await persistActivity(context);
+    }),
+  );
+
+  context.subscriptions.push(
     vscode.tasks.onDidStartTaskProcess((event) => {
       const task = event.execution.task;
       recordFirstActionLag();
@@ -843,6 +857,7 @@ export function activate(context: vscode.ExtensionContext): void {
         state.lastTaskEndedAt = Date.now();
       }
 
+      markBoundarySignal();
       markMeaningfulActivity();
       await persistTaskMetadata(context);
       rerenderPanel();
@@ -1143,12 +1158,17 @@ function registerTerminalHooks(context: vscode.ExtensionContext): vscode.Disposa
       workspaceRoot,
       config.redactionPatterns,
     );
+    const testOrBuildCommand = isTestOrBuildCommand(command);
+    if (typeof exitCode === 'number' && testOrBuildCommand) {
+      markBoundarySignal();
+      markMeaningfulActivity();
+    }
 
     if (
       config.includeTerminalHistory &&
       typeof exitCode === 'number' &&
       exitCode !== 0 &&
-      isTestOrBuildCommand(command)
+      testOrBuildCommand
     ) {
       state.lastFailingCommandRaw = command;
       state.lastFailingCommand = sanitizedCommand;
@@ -1159,7 +1179,7 @@ function registerTerminalHooks(context: vscode.ExtensionContext): vscode.Disposa
       config.includeTerminalHistory &&
       typeof exitCode === 'number' &&
       exitCode === 0 &&
-      isTestOrBuildCommand(command)
+      testOrBuildCommand
     ) {
       state.doneItems.push(sanitizedCommand);
 
@@ -1599,8 +1619,12 @@ async function presentSummary(
       trigger: triggerReason,
       uiSurface: config.uiSurface,
       interruptionEvent: triggerReason === 'focus' && config.uiSurface === 'notification' ? 1 : 0,
+      interruptionTimingClass: classifyInterruptionTiming(triggerReason),
       resumeWithNote: options.checkpointPrimaryNote ? 1 : 0,
     };
+    if (summary.nextSteps[0]) {
+      recordCompanionPrimaryCtaImpression();
+    }
   }
 
   const workspaceRoot = pickWorkspaceRoot(options.workspaceRoot);
@@ -1759,6 +1783,31 @@ function resolveCompanionRuntimeMode(config: ExtensionConfig): CompanionRuntimeM
   return 'active';
 }
 
+function classifyInterruptionTiming(
+  triggerReason: TriggerReason,
+): 'boundary' | 'mid-activity' | 'unknown' {
+  if (triggerReason !== 'focus') {
+    return 'unknown';
+  }
+
+  const now = Date.now();
+  if (
+    state.lastBoundarySignalAt > 0 &&
+    now - state.lastBoundarySignalAt <= INTERRUPTION_TIMING_BOUNDARY_WINDOW_MS
+  ) {
+    return 'boundary';
+  }
+
+  if (
+    state.lastMeaningfulActivityAt > 0 &&
+    now - state.lastMeaningfulActivityAt <= INTERRUPTION_TIMING_MID_ACTIVITY_WINDOW_MS
+  ) {
+    return 'mid-activity';
+  }
+
+  return 'unknown';
+}
+
 function recordFirstActionLag(): void {
   if (!state.metricSession || state.metricSession.firstActionLagMs !== undefined) {
     return;
@@ -1812,6 +1861,34 @@ function recordCompanionNudgeImpression(): void {
 
   state.metricSession.companionNudgeImpressions =
     (state.metricSession.companionNudgeImpressions ?? 0) + 1;
+}
+
+function recordCompanionPrimaryCtaImpression(): void {
+  if (!state.metricSession) {
+    return;
+  }
+
+  state.metricSession.companionPrimaryCtaImpressions =
+    (state.metricSession.companionPrimaryCtaImpressions ?? 0) + 1;
+}
+
+function recordCompanionPrimaryCtaClick(): void {
+  if (!state.metricSession) {
+    return;
+  }
+
+  recordCompanionFirstActionLag();
+  state.metricSession.companionPrimaryCtaClicks =
+    (state.metricSession.companionPrimaryCtaClicks ?? 0) + 1;
+}
+
+function recordCompanionPrimaryCtaCompletion(): void {
+  if (!state.metricSession) {
+    return;
+  }
+
+  state.metricSession.companionPrimaryCtaCompletions =
+    (state.metricSession.companionPrimaryCtaCompletions ?? 0) + 1;
 }
 
 function recordMetricCounter(
@@ -2454,7 +2531,18 @@ async function showDetailsPanel(
         }
 
         recordCompanionQuickAction();
-        await runNextStepAction(state.panelSummary, message.stepIndex, state.panelWorkspaceRoot);
+        const isPrimaryStep = message.stepIndex === 0;
+        if (isPrimaryStep) {
+          recordCompanionPrimaryCtaClick();
+        }
+        const completed = await runNextStepAction(
+          state.panelSummary,
+          message.stepIndex,
+          state.panelWorkspaceRoot,
+        );
+        if (isPrimaryStep && completed) {
+          recordCompanionPrimaryCtaCompletion();
+        }
         return;
       }
 
@@ -3830,7 +3918,12 @@ function renderStepEvidenceBadge(evidenceId: string, evidence?: SummaryEvidenceI
   return `<span class="badge">${escapeHtml(label)}</span>`;
 }
 
+function markBoundarySignal(): void {
+  state.lastBoundarySignalAt = Date.now();
+}
+
 function markMeaningfulActivity(): void {
+  state.lastMeaningfulActivityAt = Date.now();
   state.meaningfulActivitySinceCheckpointPrompt = true;
 }
 
@@ -4266,6 +4359,8 @@ async function applyTaskPartitionSwitch(
   state.doneItems = new RingBuffer(10, snapshot.sanitized.doneItems);
   state.lastFailingCommand = snapshot.sanitized.lastFailingCommand;
   state.lastFailingCommandRaw = undefined;
+  state.lastBoundarySignalAt = 0;
+  state.lastMeaningfulActivityAt = 0;
   state.scratchSummary = undefined;
   if (state.panel) {
     state.panel.dispose();
@@ -4592,10 +4687,10 @@ async function runNextStepAction(
   summary: ResumeSummary,
   stepIndex: number,
   preferredWorkspaceRoot?: string,
-): Promise<void> {
+): Promise<boolean> {
   if (!Number.isInteger(stepIndex) || stepIndex < 0 || stepIndex >= summary.nextSteps.length) {
     void vscode.window.showWarningMessage('TaCoS blocked an invalid next-step action target.');
-    return;
+    return false;
   }
 
   const availability = computeRestoreAvailability({
@@ -4618,28 +4713,26 @@ async function runNextStepAction(
     void vscode.window.showInformationMessage(
       'TaCoS: this step has no verified clickable action yet. Use evidence links to continue.',
     );
-    return;
+    return false;
   }
 
   const evidence = (summary.evidenceCatalog ?? []).find((item) => item.id === action.evidenceId);
   if (!evidence) {
     void vscode.window.showWarningMessage('TaCoS blocked a stale next-step action.');
-    return;
+    return false;
   }
 
   if (action.kind === 'copyFailingCommand') {
     await copyFailingCommand();
-    return;
+    return true;
   }
 
   if (action.kind === 'rerunTask') {
-    await rerunLastTask();
-    return;
+    return rerunLastTask();
   }
 
   if (action.kind === 'rerunDebug') {
-    await rerunLastDebugSession();
-    return;
+    return rerunLastDebugSession();
   }
 
   if (action.kind === 'openFile') {
@@ -4648,28 +4741,31 @@ async function runNextStepAction(
       void vscode.window.showWarningMessage(
         'TaCoS blocked file action because no workspace root is available for validation.',
       );
-      return;
+      return false;
     }
 
     const safeTarget = resolveFileTargetInWorkspace(evidence.target ?? '', workspaceRoot);
     if (!safeTarget || !isPathWithinWorkspaceRoot(workspaceRoot, safeTarget)) {
       void vscode.window.showWarningMessage('TaCoS blocked an unsafe next-step file target.');
-      return;
+      return false;
     }
 
     await vscode.commands.executeCommand('vscode.open', vscode.Uri.file(safeTarget));
-    return;
+    return true;
   }
 
   if (action.kind === 'openUrl') {
     const safeUrl = normalizeHttpUrl(evidence.target ?? '');
     if (!safeUrl) {
       void vscode.window.showWarningMessage('TaCoS blocked an unsafe next-step URL.');
-      return;
+      return false;
     }
 
     await vscode.env.openExternal(vscode.Uri.parse(safeUrl));
+    return true;
   }
+
+  return false;
 }
 
 function recentEditLocationsStorageKey(workspaceRoot: string): string {
@@ -6486,6 +6582,8 @@ function resetRuntimeWorkspaceState(): void {
   state.lastTerminalCwd = undefined;
   state.lastDebugConfigName = undefined;
   state.lastDebugWorkspaceRoot = undefined;
+  state.lastBoundarySignalAt = 0;
+  state.lastMeaningfulActivityAt = 0;
   state.snoozeUntil = 0;
   state.panelCheckpointNotes = [];
   state.panelPrimaryCheckpointNote = undefined;

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -8,6 +8,7 @@ const CSV_HEADERS = [
   'trigger',
   'uiSurface',
   'interruptionEvent',
+  'interruptionTimingClass',
   'firstMeaningfulEditLagMs',
   'firstRunLagMs',
   'firstActionLagMs',
@@ -16,6 +17,9 @@ const CSV_HEADERS = [
   'companionForcedOpenDetailsClicks',
   'companionQuickActionsTaken',
   'companionNudgeImpressions',
+  'companionPrimaryCtaImpressions',
+  'companionPrimaryCtaClicks',
+  'companionPrimaryCtaCompletions',
   'helpfulnessRating',
   'pauseActions',
   'snoozeActions',
@@ -23,6 +27,7 @@ const CSV_HEADERS = [
   'noteCreated',
   'noteMarkedDone',
   'notePinned',
+  'resumePathCompletions',
   'resumeWithNote',
   'scratchpadOpened',
   'scratchpadAppended',
@@ -32,6 +37,8 @@ const CSV_HEADERS = [
   'aiSendAllowedAfterReviewTotal',
   'companionActionFollowThroughRate',
   'companionForcedOpenRate',
+  'companionPrimaryCtaClickThroughRate',
+  'companionPrimaryCtaCompletionRate',
 ] as const;
 
 function csvEscape(value: string): string {
@@ -113,6 +120,23 @@ function summarizeTotal(metrics: MetricRecord[], field: keyof MetricRecord): num
   return metrics.reduce((sum, metric) => sum + (toFiniteNumber(metric[field]) ?? 0), 0);
 }
 
+function summarizeTimingClassCounts(
+  metrics: MetricRecord[],
+): Record<'boundary' | 'mid-activity' | 'unknown', number> {
+  const counts = {
+    boundary: 0,
+    'mid-activity': 0,
+    unknown: 0,
+  };
+  for (const metric of metrics) {
+    const value = metric.interruptionTimingClass;
+    if (value === 'boundary' || value === 'mid-activity' || value === 'unknown') {
+      counts[value] += 1;
+    }
+  }
+  return counts;
+}
+
 export interface MetricsBaselineSnapshotOptions {
   generatedAt?: number;
   sourceLabel?: string;
@@ -136,9 +160,13 @@ export function buildMetricsBaselineSnapshotMarkdown(
   const promptImpressions = summarizeTotal(metrics, 'companionPromptImpressions');
   const forcedOpenClicks = summarizeTotal(metrics, 'companionForcedOpenDetailsClicks');
   const nudgeImpressions = summarizeTotal(metrics, 'companionNudgeImpressions');
+  const primaryCtaImpressions = summarizeTotal(metrics, 'companionPrimaryCtaImpressions');
+  const primaryCtaClicks = summarizeTotal(metrics, 'companionPrimaryCtaClicks');
+  const primaryCtaCompletions = summarizeTotal(metrics, 'companionPrimaryCtaCompletions');
   const notesCreated = summarizeTotal(metrics, 'noteCreated');
   const notesMarkedDone = summarizeTotal(metrics, 'noteMarkedDone');
   const notesPinned = summarizeTotal(metrics, 'notePinned');
+  const resumePathCompletions = summarizeTotal(metrics, 'resumePathCompletions');
   const scratchpadOpened = summarizeTotal(metrics, 'scratchpadOpened');
   const scratchpadAppended = summarizeTotal(metrics, 'scratchpadAppended');
   const redactionEventsTotal = summarizeTotal(metrics, 'redactionEventsTotal');
@@ -155,8 +183,15 @@ export function buildMetricsBaselineSnapshotMarkdown(
     'firstActionLagMs',
   );
   const forcedOpenRate = promptImpressions > 0 ? forcedOpenClicks / promptImpressions : undefined;
+  const primaryCtaClickThroughRate =
+    primaryCtaImpressions > 0 ? primaryCtaClicks / primaryCtaImpressions : undefined;
+  const primaryCtaCompletionRate =
+    primaryCtaClicks > 0 ? primaryCtaCompletions / primaryCtaClicks : undefined;
   const promptPerSession = sessions > 0 ? promptImpressions / sessions : undefined;
   const nudgePerSession = sessions > 0 ? nudgeImpressions / sessions : undefined;
+  const timingClassCounts = summarizeTimingClassCounts(metrics);
+  const timingClassRate = (value: number): number | undefined =>
+    sessions > 0 ? value / sessions : undefined;
 
   const lines = [
     '# TaCoS Metrics Baseline Snapshot',
@@ -187,15 +222,29 @@ export function buildMetricsBaselineSnapshotMarkdown(
     `| Forced-open rate (\`forced/prompt\`) | ${formatNumber(forcedOpenRate, 4)} |`,
     `| Nudge impressions (total) | ${nudgeImpressions} |`,
     `| Nudge impressions per session | ${formatNumber(nudgePerSession)} |`,
+    `| Primary CTA impressions (total) | ${primaryCtaImpressions} |`,
+    `| Primary CTA clicks (total) | ${primaryCtaClicks} |`,
+    `| Primary CTA completions (total) | ${primaryCtaCompletions} |`,
+    `| Primary CTA click-through rate (\`clicks/impressions\`) | ${formatNumber(primaryCtaClickThroughRate, 4)} |`,
+    `| Primary CTA completion rate (\`completions/clicks\`) | ${formatNumber(primaryCtaCompletionRate, 4)} |`,
     `| noteCreated (total) | ${notesCreated} |`,
     `| noteMarkedDone (total) | ${notesMarkedDone} |`,
     `| notePinned (total) | ${notesPinned} |`,
+    `| resumePathCompletions (total) | ${resumePathCompletions} |`,
     `| scratchpadOpened (total) | ${scratchpadOpened} |`,
     `| scratchpadAppended (total) | ${scratchpadAppended} |`,
     `| redactionEventsTotal (total) | ${redactionEventsTotal} |`,
     `| redactionHighRiskDetectedTotal (total) | ${redactionHighRiskDetectedTotal} |`,
     `| aiSendBlockedBySanitizerTotal (total) | ${aiSendBlockedBySanitizerTotal} |`,
     `| aiSendAllowedAfterReviewTotal (total) | ${aiSendAllowedAfterReviewTotal} |`,
+    '',
+    'Interruption timing class:',
+    '',
+    '| Class | Sessions | Share |',
+    '| --- | ---: | ---: |',
+    `| boundary | ${timingClassCounts.boundary} | ${formatNumber(timingClassRate(timingClassCounts.boundary), 4)} |`,
+    `| mid-activity | ${timingClassCounts['mid-activity']} | ${formatNumber(timingClassRate(timingClassCounts['mid-activity']), 4)} |`,
+    `| unknown | ${timingClassCounts.unknown} | ${formatNumber(timingClassRate(timingClassCounts.unknown), 4)} |`,
     '',
     'Resumption lag by note usage (`firstActionLagMs`):',
     '',
@@ -222,6 +271,9 @@ export function hasAnyRecordedMetric(metric: MetricRecord): boolean {
     metric.trigger === 'focus' ||
     metric.trigger === 'manual' ||
     metric.trigger === 'cached' ||
+    metric.interruptionTimingClass === 'boundary' ||
+    metric.interruptionTimingClass === 'mid-activity' ||
+    metric.interruptionTimingClass === 'unknown' ||
     metric.firstMeaningfulEditLagMs !== undefined ||
     metric.firstRunLagMs !== undefined ||
     metric.firstActionLagMs !== undefined ||
@@ -230,6 +282,9 @@ export function hasAnyRecordedMetric(metric: MetricRecord): boolean {
     (metric.companionForcedOpenDetailsClicks ?? 0) > 0 ||
     (metric.companionQuickActionsTaken ?? 0) > 0 ||
     (metric.companionNudgeImpressions ?? 0) > 0 ||
+    (metric.companionPrimaryCtaImpressions ?? 0) > 0 ||
+    (metric.companionPrimaryCtaClicks ?? 0) > 0 ||
+    (metric.companionPrimaryCtaCompletions ?? 0) > 0 ||
     typeof metric.helpfulnessRating === 'number' ||
     (metric.pauseActions ?? 0) > 0 ||
     (metric.snoozeActions ?? 0) > 0 ||
@@ -237,6 +292,7 @@ export function hasAnyRecordedMetric(metric: MetricRecord): boolean {
     (metric.noteCreated ?? 0) > 0 ||
     (metric.noteMarkedDone ?? 0) > 0 ||
     (metric.notePinned ?? 0) > 0 ||
+    (metric.resumePathCompletions ?? 0) > 0 ||
     metric.resumeWithNote === 1 ||
     (metric.scratchpadOpened ?? 0) > 0 ||
     (metric.scratchpadAppended ?? 0) > 0 ||
@@ -254,6 +310,9 @@ export function buildMetricsCsv(metrics: MetricRecord[]): string {
     const prompts = metric.companionPromptImpressions ?? 0;
     const forcedOpens = metric.companionForcedOpenDetailsClicks ?? 0;
     const quickActions = metric.companionQuickActionsTaken ?? 0;
+    const primaryCtaImpressions = metric.companionPrimaryCtaImpressions ?? 0;
+    const primaryCtaClicks = metric.companionPrimaryCtaClicks ?? 0;
+    const primaryCtaCompletions = metric.companionPrimaryCtaCompletions ?? 0;
     const sessionDate = new Date(metric.startedAt).toISOString().slice(0, 10);
     const fields = [
       String(metric.startedAt),
@@ -263,6 +322,7 @@ export function buildMetricsCsv(metrics: MetricRecord[]): string {
       metric.trigger,
       metric.uiSurface ?? '',
       toOptionalNumber(metric.interruptionEvent),
+      metric.interruptionTimingClass ?? '',
       toOptionalNumber(metric.firstMeaningfulEditLagMs),
       toOptionalNumber(metric.firstRunLagMs),
       toOptionalNumber(metric.firstActionLagMs),
@@ -271,6 +331,9 @@ export function buildMetricsCsv(metrics: MetricRecord[]): string {
       toOptionalNumber(metric.companionForcedOpenDetailsClicks),
       toOptionalNumber(metric.companionQuickActionsTaken),
       toOptionalNumber(metric.companionNudgeImpressions),
+      toOptionalNumber(metric.companionPrimaryCtaImpressions),
+      toOptionalNumber(metric.companionPrimaryCtaClicks),
+      toOptionalNumber(metric.companionPrimaryCtaCompletions),
       toOptionalNumber(metric.helpfulnessRating),
       toOptionalNumber(metric.pauseActions),
       toOptionalNumber(metric.snoozeActions),
@@ -278,6 +341,7 @@ export function buildMetricsCsv(metrics: MetricRecord[]): string {
       toOptionalNumber(metric.noteCreated),
       toOptionalNumber(metric.noteMarkedDone),
       toOptionalNumber(metric.notePinned),
+      toOptionalNumber(metric.resumePathCompletions),
       toOptionalNumber(metric.resumeWithNote),
       toOptionalNumber(metric.scratchpadOpened),
       toOptionalNumber(metric.scratchpadAppended),
@@ -287,6 +351,8 @@ export function buildMetricsCsv(metrics: MetricRecord[]): string {
       toOptionalNumber(metric.aiSendAllowedAfterReviewTotal),
       toRatio(quickActions, prompts),
       toRatio(forcedOpens, prompts),
+      toRatio(primaryCtaClicks, primaryCtaImpressions),
+      toRatio(primaryCtaCompletions, primaryCtaClicks),
     ];
 
     lines.push(fields.map((value) => csvEscape(value)).join(','));

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,7 @@ export interface MetricRecord {
   trigger: TriggerReason;
   uiSurface?: UiSurface;
   interruptionEvent?: number;
+  interruptionTimingClass?: 'boundary' | 'mid-activity' | 'unknown';
   firstMeaningfulEditLagMs?: number;
   firstRunLagMs?: number;
   firstActionLagMs?: number;
@@ -137,6 +138,9 @@ export interface MetricRecord {
   companionForcedOpenDetailsClicks?: number;
   companionQuickActionsTaken?: number;
   companionNudgeImpressions?: number;
+  companionPrimaryCtaImpressions?: number;
+  companionPrimaryCtaClicks?: number;
+  companionPrimaryCtaCompletions?: number;
   helpfulnessRating?: 1 | 2 | 3 | 4 | 5;
   pauseActions?: number;
   snoozeActions?: number;
@@ -144,6 +148,7 @@ export interface MetricRecord {
   noteCreated?: number;
   noteMarkedDone?: number;
   notePinned?: number;
+  resumePathCompletions?: number;
   resumeWithNote?: 0 | 1;
   scratchpadOpened?: number;
   scratchpadAppended?: number;

--- a/test/metrics.test.ts
+++ b/test/metrics.test.ts
@@ -61,6 +61,17 @@ describe('hasAnyRecordedMetric', () => {
 
     expect(hasAnyRecordedMetric(metric)).toBe(true);
   });
+
+  it('treats interruption timing class annotations as recorded metric activity', () => {
+    const metric: MetricRecord = {
+      startedAt: Date.UTC(2026, 1, 1, 12, 0, 0),
+      workspaceRoot: '/workspace/repo',
+      trigger: 'focus',
+      interruptionTimingClass: 'boundary',
+    };
+
+    expect(hasAnyRecordedMetric(metric)).toBe(true);
+  });
 });
 
 describe('buildMetricsCsv', () => {
@@ -72,16 +83,21 @@ describe('buildMetricsCsv', () => {
         trigger: 'manual',
         uiSurface: 'statusbar',
         interruptionEvent: 0,
+        interruptionTimingClass: 'unknown',
         firstMeaningfulEditLagMs: 1200,
         firstRunLagMs: 2100,
         firstActionLagMs: 1300,
         companionPromptImpressions: 4,
         companionForcedOpenDetailsClicks: 1,
         companionQuickActionsTaken: 3,
+        companionPrimaryCtaImpressions: 2,
+        companionPrimaryCtaClicks: 1,
+        companionPrimaryCtaCompletions: 1,
         helpfulnessRating: 4,
         pauseActions: 1,
         snoozeActions: 0,
         disableActions: 0,
+        resumePathCompletions: 0,
         scratchpadOpened: 2,
         scratchpadAppended: 1,
       },
@@ -91,6 +107,13 @@ describe('buildMetricsCsv', () => {
     expect(lines[0]).toContain('firstActionLagMs');
     expect(lines[0]).toContain('helpfulnessRating');
     expect(lines[0]).toContain('companionActionFollowThroughRate');
+    expect(lines[0]).toContain('interruptionTimingClass');
+    expect(lines[0]).toContain('companionPrimaryCtaImpressions');
+    expect(lines[0]).toContain('companionPrimaryCtaClicks');
+    expect(lines[0]).toContain('companionPrimaryCtaCompletions');
+    expect(lines[0]).toContain('resumePathCompletions');
+    expect(lines[0]).toContain('companionPrimaryCtaClickThroughRate');
+    expect(lines[0]).toContain('companionPrimaryCtaCompletionRate');
     expect(lines[0]).toContain('noteCreated');
     expect(lines[0]).toContain('resumeWithNote');
     expect(lines[0]).toContain('scratchpadOpened');
@@ -101,10 +124,8 @@ describe('buildMetricsCsv', () => {
     expect(lines[0]).toContain('aiSendAllowedAfterReviewTotal');
     expect(lines).toHaveLength(2);
     expect(lines[1]).toContain('"/workspace/repo,feature"');
-    expect(lines[1]).toContain(',statusbar,0,');
-    expect(lines[1]).toContain(',2,1,,,,,0.7500,');
-    expect(lines[1]).toContain(',0.7500,');
-    expect(lines[1]).toContain(',0.2500');
+    expect(lines[1]).toContain(',statusbar,0,unknown,');
+    expect(lines[1]).toContain(',0.7500,0.2500,0.5000,1.0000');
   });
 });
 
@@ -167,6 +188,10 @@ describe('buildMetricsBaselineSnapshotMarkdown', () => {
           companionPromptImpressions: 2,
           companionForcedOpenDetailsClicks: 1,
           companionNudgeImpressions: 1,
+          companionPrimaryCtaImpressions: 1,
+          companionPrimaryCtaClicks: 1,
+          companionPrimaryCtaCompletions: 1,
+          interruptionTimingClass: 'boundary',
           scratchpadOpened: 1,
         },
         {
@@ -179,6 +204,10 @@ describe('buildMetricsBaselineSnapshotMarkdown', () => {
           companionPromptImpressions: 3,
           companionForcedOpenDetailsClicks: 1,
           companionNudgeImpressions: 2,
+          companionPrimaryCtaImpressions: 2,
+          companionPrimaryCtaClicks: 1,
+          companionPrimaryCtaCompletions: 1,
+          interruptionTimingClass: 'mid-activity',
           scratchpadAppended: 2,
         },
         {
@@ -187,6 +216,7 @@ describe('buildMetricsBaselineSnapshotMarkdown', () => {
           trigger: 'cached',
           firstMeaningfulEditLagMs: 3000,
           firstActionLagMs: 3500,
+          interruptionTimingClass: 'unknown',
         },
       ],
       { generatedAt: Date.UTC(2026, 1, 1, 12, 0, 0) },
@@ -206,6 +236,16 @@ describe('buildMetricsBaselineSnapshotMarkdown', () => {
     expect(markdown).toContain('| Forced-open rate (`forced/prompt`) | 0.4000 |');
     expect(markdown).toContain('| Nudge impressions (total) | 3 |');
     expect(markdown).toContain('| Nudge impressions per session | 1.00 |');
+    expect(markdown).toContain('| Primary CTA impressions (total) | 3 |');
+    expect(markdown).toContain('| Primary CTA clicks (total) | 2 |');
+    expect(markdown).toContain('| Primary CTA completions (total) | 2 |');
+    expect(markdown).toContain(
+      '| Primary CTA click-through rate (`clicks/impressions`) | 0.6667 |',
+    );
+    expect(markdown).toContain('| Primary CTA completion rate (`completions/clicks`) | 1.0000 |');
+    expect(markdown).toContain('| boundary | 1 | 0.3333 |');
+    expect(markdown).toContain('| mid-activity | 1 | 0.3333 |');
+    expect(markdown).toContain('| unknown | 1 | 0.3333 |');
     expect(markdown).toContain('| scratchpadOpened (total) | 1 |');
     expect(markdown).toContain('| scratchpadAppended (total) | 2 |');
   });


### PR DESCRIPTION
## What changed
- Added local-only metric fields for v0.6 recovery effectiveness:
  - `interruptionTimingClass` (`boundary`, `mid-activity`, `unknown`)
  - `companionPrimaryCtaImpressions`
  - `companionPrimaryCtaClicks`
  - `companionPrimaryCtaCompletions`
  - `resumePathCompletions` (exported now for upcoming checklist work)
- Recorded interruption timing class at summary presentation using recent boundary/activity timestamps.
- Recorded primary CTA impression/click/completion from existing next-step action flow (step index `0` in panel).
- Extended metrics export + baseline snapshot:
  - New CSV columns and derived rates:
    - `companionPrimaryCtaClickThroughRate`
    - `companionPrimaryCtaCompletionRate`
  - Baseline snapshot includes CTA totals/rates and timing-class breakdown table.
- Updated docs (`docs/metrics.md`) for metric dictionary and snapshot semantics.
- Added/updated tests in `test/metrics.test.ts` for headers, rows, derived rates, timing-class persistence, and snapshot output.

## Why (cognitive rationale)
- v0.6 depends on proving that assistant cues (clear next action) improve resumption behavior. Without CTA impression/click/completion counters we cannot measure this locally.
- Interruption timing quality matters: boundary moments should be less disruptive than mid-activity interruptions. `interruptionTimingClass` gives us the minimal local observable to validate timing improvements.
- All instrumentation remains local-only and privacy-preserving, consistent with TaCoS trust posture.

## How tested
- `npm run verify`
  - format check
  - lint
  - TypeScript compile
  - unit tests
  - integration tests
  - package build

## How to verify manually
1. Run `TaCoS: Show Companion Home` or trigger a focus resume summary with at least one next step.
2. Click the first next-step action in the panel and complete it.
3. Export metrics (`TaCoS: Export Metrics CSV`) and verify new fields exist in `.tacos/metrics.csv`.
4. Copy baseline snapshot (`TaCoS: Copy Metrics Baseline Snapshot`) and verify:
   - primary CTA totals/rates rows
   - interruption timing class table (`boundary`, `mid-activity`, `unknown`).
5. Confirm no network calls or external telemetry behavior changes.

## Performance impact notes
- Added O(1) timestamp updates on existing boundary/activity hooks (task end, debug end, terminal command completion).
- Added constant-time metric counter increments on existing UI action handlers.
- No new polling loops, no additional blocking work on focus path, and no change to summary synthesis complexity.
