### PR TITLE
v0.6.0: Refactor renderWebview into composable modules for safer UX iteration (fixes #148)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -102,6 +102,20 @@ import {
   normalizeIntentOverrideState,
   normalizeIntentOverrideText,
 } from './intentOverride';
+import { renderPanelClientScript } from './webview/panelClientScript';
+import {
+  renderChangesSinceCard,
+  renderDetailsCard,
+  renderEvidenceCard,
+  renderQuickActionsCard,
+  renderRecapCard,
+  renderRestorePackCard,
+  renderStatusCard,
+  renderTimelineCard,
+  renderTitledListCard,
+  renderTrustCenterCard,
+} from './webview/panelCards';
+import { PANEL_WEBVIEW_STYLE } from './webview/panelStyles';
 import {
   buildResumePathSteps,
   buildResumePathStorageKey,
@@ -4215,48 +4229,23 @@ function renderWebview(
       return `<section class="timeline-group"><h4>${escapeHtml(group.label)}</h4><ul>${items}</ul></section>`;
     })
     .join('');
-  const timelineCard = config.showTimeline
-    ? `<div class="card">
-      <h3>Timeline</h3>
-      <button type="button" class="secondary" data-action="toggleTimeline" aria-expanded="false" aria-controls="timeline-content">Show timeline</button>
-      <div id="timeline-content" hidden>
-        ${timelineGroupsHtml || '<p class="muted">No timeline entries captured yet.</p>'}
-      </div>
-    </div>`
-    : '';
+  const timelineCard = renderTimelineCard({
+    showTimeline: config.showTimeline,
+    timelineGroupsTrustedHtml: timelineGroupsHtml,
+  });
   const recapCard =
     recapDoneItems.length > 0 || recapPendingItems.length > 0 || Boolean(recapFirstAction)
-      ? `<div class="card recap-card">
-      <h3>Session Recap</h3>
-      <div class="recap-grid">
-        <section>
-          <h4>Done since last resume</h4>
-          <ul class="compact-list">${recapDoneList || '<li>None captured yet.</li>'}</ul>
-        </section>
-        <section>
-          <h4>Pending / blocked</h4>
-          <ul class="compact-list">${recapPendingList || '<li>No blocker captured.</li>'}</ul>
-        </section>
-        <section>
-          <h4>Next safe action</h4>
-          <p class="companion-primary">${escapeHtml(recapFirstAction || 'Refresh summary to regenerate first-action guidance.')}</p>
-          <div class="status-actions">
-            ${recapPrimaryNextActionButton}
-            <button type="button" class="secondary" data-action="copyNextSteps">Copy next steps</button>
-            <button type="button" class="secondary" data-action="sessionAddCheckpoint">Add note</button>
-            <button type="button" class="secondary" data-action="checkpointOpenList">List notes</button>
-          </div>
-        </section>
-      </div>
-    </div>`
+      ? renderRecapCard({
+          recapDoneListTrustedHtml: recapDoneList,
+          recapPendingListTrustedHtml: recapPendingList,
+          recapFirstAction: recapFirstAction ?? '',
+          recapPrimaryNextActionButtonTrustedHtml: recapPrimaryNextActionButton,
+        })
       : '';
   const changesSinceItems = (summary.changesSinceLastResume ?? [])
     .map((item) => `<li>${escapeHtml(item)}</li>`)
     .join('');
-  const changesSinceCard = `<div class="card">
-      <h3>Changes Since Last Time</h3>
-      <ul class="compact-list">${changesSinceItems || '<li>No changes captured.</li>'}</ul>
-    </div>`;
+  const changesSinceCard = renderChangesSinceCard(changesSinceItems);
   const nudgeCard =
     primaryNudge || secondaryNudge || nudgeSuppressionLabel
       ? `<div class="card">
@@ -4286,391 +4275,55 @@ function renderWebview(
     </div>`
       : '';
 
-  return `<!doctype html>
-<html>
-  <head>
-    <meta charset="utf-8" />
-    ${cspMetaTag}
-    <style nonce="${nonce}">
-      :root {
-        --surface-bg: var(--vscode-editorWidget-background);
-        --surface-border: var(--vscode-panel-border);
-        --surface-muted: var(--vscode-descriptionForeground);
-        --surface-strong: var(--vscode-foreground);
-        --accent: var(--vscode-focusBorder);
-      }
-      body {
-        color: var(--surface-strong);
-        background: var(--vscode-editor-background);
-        font-family: var(--vscode-font-family);
-        font-size: var(--vscode-font-size);
-        line-height: 1.5;
-        padding: 16px;
-      }
-      .card {
-        border: 1px solid var(--surface-border);
-        border-radius: 12px;
-        padding: 14px;
-        margin-bottom: 14px;
-        background: var(--surface-bg);
-      }
-      ul {
-        padding-left: 20px;
-      }
-      h3 {
-        margin-top: 0;
-        margin-bottom: 10px;
-        display: flex;
-        align-items: center;
-        gap: 8px;
-      }
-      h3::before {
-        content: '';
-        width: 8px;
-        height: 8px;
-        border-radius: 999px;
-        background: var(--accent);
-      }
-      h4 {
-        margin-bottom: 8px;
-      }
-      a {
-        color: var(--vscode-textLink-foreground);
-      }
-      a:hover {
-        color: var(--vscode-textLink-activeForeground);
-      }
-      pre {
-        white-space: pre-wrap;
-        word-break: break-word;
-      }
-      .details-markdown {
-        line-height: 1.45;
-      }
-      .details-markdown > :first-child {
-        margin-top: 0;
-      }
-      .details-markdown > :last-child {
-        margin-bottom: 0;
-      }
-      .details-markdown p,
-      .details-markdown li {
-        overflow-wrap: anywhere;
-      }
-      .details-markdown code {
-        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
-      }
-      .kind {
-        color: var(--vscode-descriptionForeground);
-      }
-      .mode {
-        color: var(--vscode-descriptionForeground);
-        font-size: 13px;
-      }
-      .status-label {
-        font-weight: 700;
-        font-size: 13px;
-      }
-      .status-detail {
-        margin-top: 6px;
-      }
-      .status-actions {
-        margin-top: 10px;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-      }
-      .step-evidence {
-        margin-top: 6px;
-        display: flex;
-        gap: 6px;
-        flex-wrap: wrap;
-      }
-      .step-actions {
-        margin-top: 8px;
-      }
-      .step-action {
-        padding: 4px 10px;
-        font-size: 12px;
-      }
-      .step-advisory {
-        margin-top: 6px;
-        font-size: 12px;
-      }
-      .badge {
-        display: inline-block;
-        border: 1px solid var(--vscode-widget-border);
-        border-radius: 999px;
-        padding: 2px 8px;
-        font-size: 12px;
-        text-decoration: none;
-        color: inherit;
-      }
-      .badge.clickable {
-        cursor: pointer;
-      }
-      .badge.kind-url {
-        border-color: var(--vscode-textLink-foreground);
-      }
-      .badge.kind-file {
-        border-color: var(--vscode-charts-green);
-      }
-      .evidence-kind {
-        color: var(--vscode-descriptionForeground);
-      }
-      .evidence-target {
-        color: var(--vscode-descriptionForeground);
-      }
-      .extra-evidence {
-        display: none;
-      }
-      .evidence-list.show-more .extra-evidence {
-        display: list-item;
-      }
-      details summary {
-        cursor: pointer;
-      }
-      .show-more-btn {
-        margin-top: 8px;
-      }
-      .muted {
-        color: var(--surface-muted);
-      }
-      .resume-path-list {
-        margin-top: 10px;
-      }
-      .resume-path-item {
-        margin-bottom: 8px;
-      }
-      .resume-path-toggle {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        cursor: pointer;
-        font-weight: 600;
-      }
-      .resume-path-toggle input[type='checkbox'] {
-        width: 14px;
-        height: 14px;
-      }
-      .resume-path-detail {
-        margin: 4px 0 0 22px;
-        font-size: 12px;
-      }
-      .blocker-disabled-reason {
-        margin-top: 8px;
-      }
-      .restore-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-        gap: 8px;
-      }
-      button {
-        border: 1px solid var(--vscode-button-border, transparent);
-        background: var(--vscode-button-background);
-        color: var(--vscode-button-foreground);
-        border-radius: 8px;
-        padding: 8px 10px;
-      }
-      button:focus-visible {
-        outline: 2px solid var(--vscode-focusBorder);
-        outline-offset: 2px;
-      }
-      button.secondary {
-        background: transparent;
-        color: var(--vscode-editor-foreground);
-        border-color: var(--vscode-widget-border);
-      }
-      .restore-grid button {
-        text-align: left;
-        cursor: pointer;
-      }
-      .restore-grid button:disabled {
-        opacity: 0.5;
-        cursor: default;
-      }
-      .restore-note {
-        color: var(--vscode-descriptionForeground);
-        font-size: 12px;
-        margin-top: 8px;
-      }
-      .note-actions {
-        display: flex;
-        gap: 8px;
-        flex-wrap: wrap;
-      }
-      .note-actions button {
-        border-radius: 6px;
-        padding: 6px 10px;
-        cursor: pointer;
-      }
-      .timeline-group ul {
-        margin-top: 0;
-      }
-      .timeline-group li {
-        display: grid;
-        grid-template-columns: 70px 1fr;
-        gap: 8px;
-        margin-bottom: 6px;
-      }
-      .timeline-time {
-        color: var(--vscode-descriptionForeground);
-        font-size: 12px;
-        padding-top: 2px;
-      }
-      .timeline-row {
-        display: flex;
-        flex-direction: column;
-        gap: 2px;
-      }
-      .timeline-detail {
-        color: var(--vscode-descriptionForeground);
-        font-size: 12px;
-        overflow-wrap: anywhere;
-      }
-      .quick-actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-      }
-      .quick-actions button {
-        min-width: 160px;
-      }
-      .action-group + .action-group {
-        margin-top: 10px;
-      }
-      .action-group h4,
-      .action-group h5 {
-        margin: 0 0 8px 0;
-        font-size: 12px;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        color: var(--surface-muted);
-      }
-      .companion-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-        gap: 12px;
-      }
-      .companion-block {
-        border: 1px solid var(--vscode-widget-border);
-        border-radius: 10px;
-        padding: 12px;
-        background: var(--vscode-editor-background);
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-      }
-      .companion-block h4 {
-        margin-top: 0;
-        margin-bottom: 6px;
-        font-size: 12px;
-        text-transform: uppercase;
-        letter-spacing: 0.04em;
-        color: var(--surface-muted);
-      }
-      .companion-primary {
-        margin: 0 0 8px 0;
-        font-weight: 700;
-        line-height: 1.4;
-      }
-      .companion-kicker {
-        margin: 0;
-        font-size: 12px;
-        text-transform: uppercase;
-        letter-spacing: 0.05em;
-        color: var(--surface-muted);
-      }
-      .companion-meta {
-        margin: 0;
-        color: var(--surface-muted);
-      }
-      .intent-editor {
-        border: 1px solid var(--vscode-widget-border);
-        border-radius: 8px;
-        padding: 8px;
-      }
-      .intent-editor-row {
-        margin-top: 6px;
-      }
-      .intent-editor input[type='text'] {
-        width: 100%;
-        box-sizing: border-box;
-        padding: 6px 8px;
-        border-radius: 6px;
-        border: 1px solid var(--vscode-input-border, var(--vscode-widget-border));
-        background: var(--vscode-input-background);
-        color: var(--vscode-input-foreground);
-      }
-      .intent-editor-actions {
-        display: flex;
-        gap: 8px;
-        margin-top: 8px;
-        flex-wrap: wrap;
-      }
-      .compact-list {
-        margin: 0 0 10px 0;
-        padding-left: 18px;
-      }
-      .companion-restore-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-        gap: 6px;
-      }
-      .companion-restore-grid button {
-        text-align: left;
-      }
-      .trust-row {
-        margin-bottom: 8px;
-      }
-      .trust-key {
-        font-weight: 600;
-      }
-      .recap-card .recap-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-        gap: 10px;
-      }
-      .recap-card h4 {
-        margin-top: 0;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="card">
-      <h3>Status</h3>
-      <div class="status-label">${escapeHtml(sourceLabel)} · ${escapeHtml(generatedAtLabel)}</div>
-      <div class="status-detail muted">${escapeHtml(statusHint)}</div>
-      <div class="status-detail"><strong>${escapeHtml(autoSummaryStatusLabel)}</strong></div>
-      <div class="status-detail muted">${escapeHtml(autoSummaryStatusDetail)}</div>
-      <div class="status-actions">
-        <button type="button" data-action="refreshSummary">Refresh summary now</button>
-        <button type="button" class="secondary" data-action="toggleAutoSummaries" ${autoSummaryToggleDisabledAttr}>${escapeHtml(autoSummaryToggleLabel)}</button>
-      </div>
-    </div>
-
-    <div class="card">
-      <h3>Trust Center</h3>
-      <div class="trust-row"><span class="trust-key">Tracking:</span> ${escapeHtml(trustTrackingLabel)}</div>
-      <div class="trust-row"><span class="trust-key">Stored locally:</span> ${escapeHtml(storedLocallyLabel)}</div>
-      <div class="trust-row"><span class="trust-key">Sent to AI:</span> ${escapeHtml(sentToAiLabel)}</div>
-      <div class="trust-row"><span class="trust-key">Based on:</span> ${escapeHtml(trustCue.headline.replace('Based on: ', ''))}</div>
-      <details>
-        <summary><strong>Why am I seeing this?</strong></summary>
-        <ul class="compact-list">${trustCueDetails || '<li>No evidence counts yet.</li>'}</ul>
-      </details>
-      <div class="status-actions">
-        <button type="button" class="secondary" data-action="toggleAutoSummaries" ${autoSummaryToggleDisabledAttr}>${escapeHtml(autoSummaryToggleLabel)}</button>
-        <button type="button" class="secondary" data-action="openPrivacySafety">Open Privacy & Safety</button>
-      </div>
-    </div>
-
-    ${checkpointCard}
-    ${scratchpadCard}
-    ${recapCard}
-    ${changesSinceCard}
-    ${nudgeCard}
-    ${renderResumeStackCard({
+  const statusCard = renderStatusCard({
+    sourceLabel,
+    generatedAtLabel,
+    statusHint,
+    autoSummaryStatusLabel,
+    autoSummaryStatusDetail,
+    autoSummaryToggleDisabledAttr,
+    autoSummaryToggleLabel,
+  });
+  const trustCenterCard = renderTrustCenterCard({
+    trustTrackingLabel,
+    storedLocallyLabel,
+    sentToAiLabel,
+    trustBasedOn: trustCue.headline.replace('Based on: ', ''),
+    trustCueDetailsTrustedHtml: trustCueDetails,
+    autoSummaryToggleDisabledAttr,
+    autoSummaryToggleLabel,
+  });
+  const nextStepsCard = renderTitledListCard({
+    title: 'Next Steps',
+    listItemsTrustedHtml: nextSteps,
+    emptyMessage: 'No next steps captured yet.',
+  });
+  const topFilesCard = renderTitledListCard({
+    title: 'Top Files',
+    listItemsTrustedHtml: topFiles,
+    emptyMessage: 'None captured',
+  });
+  const topLinksCard = renderTitledListCard({
+    title: 'Top Links / Files',
+    listItemsTrustedHtml: linkItems,
+    emptyMessage: 'None captured',
+  });
+  const quickActionsCard = renderQuickActionsCard(quickActionGroups);
+  const restorePackCard = renderRestorePackCard(restorePackGroups, trusted);
+  const evidenceCard = renderEvidenceCard({
+    evidenceItemsTrustedHtml: evidenceItems,
+    hasExtraEvidence,
+  });
+  const detailsCard = renderDetailsCard(detailsHtml);
+  const bodyCards = [
+    statusCard,
+    trustCenterCard,
+    checkpointCard,
+    scratchpadCard,
+    recapCard,
+    changesSinceCard,
+    nudgeCard,
+    renderResumeStackCard({
       intent: summary.intent,
       intentOverridden: summary.intentOverridden,
       intentEditorTrustedHtml: intentEditorHtml,
@@ -4691,321 +4344,34 @@ function renderWebview(
       blockerDisabledReasonTrustedHtml: blockerDisabledReasonHtml,
       blockerActionTrustedHtml: blockerActionHtml,
       restoreSectionsTrustedHtml: companionRestoreSections,
-    })}
-    ${resumePathCard}
+    }),
+    resumePathCard,
+    confidenceCard,
+    nextStepsCard,
+    topFilesCard,
+    topLinksCard,
+    timelineCard,
+    quickActionsCard,
+    restorePackCard,
+    evidenceCard,
+    detailsCard,
+  ]
+    .filter(Boolean)
+    .join('\n\n');
+  const clientScript = renderPanelClientScript(MAX_INTENT_OVERRIDE_CHARS);
 
-    ${confidenceCard}
-
-    <div class="card">
-      <h3>Next Steps</h3>
-      <ul>${nextSteps}</ul>
-    </div>
-
-    <div class="card">
-      <h3>Top Files</h3>
-      <ul>${topFiles || '<li>None captured</li>'}</ul>
-    </div>
-
-    <div class="card">
-      <h3>Top Links / Files</h3>
-      <ul>${linkItems || '<li>None captured</li>'}</ul>
-    </div>
-
-    ${timelineCard}
-
-    <div class="card">
-      <h3>Quick Actions</h3>
-      ${quickActionGroups}
-    </div>
-
-    <div class="card">
-      <h3>Restore Pack</h3>
-      ${restorePackGroups}
-      ${
-        trusted
-          ? ''
-          : '<div class="restore-note">Restricted Mode: task/debug/branch execution actions are disabled.</div>'
-      }
-    </div>
-
-    <div class="card">
-      <details>
-        <summary><strong>Evidence</strong></summary>
-        <ul class="evidence-list" id="evidence-list">${evidenceItems || '<li>None captured</li>'}</ul>
-        ${
-          hasExtraEvidence
-            ? '<button type="button" class="show-more-btn" data-action="toggleEvidenceMore">Show more</button>'
-            : ''
-        }
-      </details>
-    </div>
-
-    <div class="card">
-      <h3>Details</h3>
-      <div class="details-markdown">${detailsHtml}</div>
-    </div>
+  return `<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    ${cspMetaTag}
+    <style nonce="${nonce}">${PANEL_WEBVIEW_STYLE}</style>
+  </head>
+  <body>
+    ${bodyCards}
 
     <script nonce="${nonce}">
-      const vscode = acquireVsCodeApi();
-      const hostActions = new Set([
-        'fixSummary',
-        'checkpointPinToggle',
-        'checkpointMarkDone',
-        'checkpointDismiss',
-        'checkpointOpenList',
-        'openScratchpad',
-        'appendScratchpad',
-        'setScratchpadScope',
-        'sessionAddCheckpoint',
-        'setIntentOverride',
-        'clearIntentOverride',
-        'copyNextSteps',
-        'copySummary',
-        'copyPromptAndOpenCodex',
-        'refreshSummary',
-        'toggleAutoSummaries',
-        'acknowledgeNudge',
-        'dismissNudge',
-        'openPrivacySafety',
-        'rateHelpfulness',
-        'runNextStepAction',
-        'restoreWorkingSet',
-        'restoreJumpToLastEdit',
-        'restoreReopenFiles',
-        'restoreOpenChangedFiles',
-        'restoreRerunTask',
-        'restoreRerunDebug',
-        'restoreOpenProblems',
-        'restoreOpenDiagnosticFile',
-        'restoreCheckoutPreviousBranch',
-        'restoreCopyFailingCommand'
-      ]);
-      const viewState = Object.assign(
-        { evidenceExpanded: false, timelineExpanded: false },
-        vscode.getState() || {},
-      );
-
-      function persistViewState() {
-        vscode.setState(viewState);
-      }
-
-      function setEvidenceExpanded(expanded) {
-        const list = document.getElementById('evidence-list');
-        const toggle = document.querySelector('[data-action="toggleEvidenceMore"]');
-        if (!(list instanceof HTMLElement) || !(toggle instanceof HTMLElement)) {
-          viewState.evidenceExpanded = false;
-          persistViewState();
-          return;
-        }
-
-        list.classList.toggle('show-more', expanded);
-        toggle.textContent = expanded ? 'Show less' : 'Show more';
-        viewState.evidenceExpanded = expanded;
-        persistViewState();
-      }
-
-      function setTimelineExpanded(expanded) {
-        const timeline = document.getElementById('timeline-content');
-        const toggle = document.querySelector('[data-action="toggleTimeline"]');
-        if (!(timeline instanceof HTMLElement) || !(toggle instanceof HTMLElement)) {
-          viewState.timelineExpanded = false;
-          persistViewState();
-          return;
-        }
-
-        if (expanded) {
-          timeline.removeAttribute('hidden');
-          toggle.textContent = 'Hide timeline';
-          toggle.setAttribute('aria-expanded', 'true');
-        } else {
-          timeline.setAttribute('hidden', 'true');
-          toggle.textContent = 'Show timeline';
-          toggle.setAttribute('aria-expanded', 'false');
-        }
-        viewState.timelineExpanded = expanded;
-        persistViewState();
-      }
-
-      setEvidenceExpanded(Boolean(viewState.evidenceExpanded));
-      setTimelineExpanded(Boolean(viewState.timelineExpanded));
-
-      function parseDatasetInteger(rawValue) {
-        if (typeof rawValue !== 'string') {
-          return undefined;
-        }
-        const parsed = Number(rawValue);
-        if (!Number.isInteger(parsed) || parsed < 0) {
-          return undefined;
-        }
-        return parsed;
-      }
-
-      const maxIntentOverrideChars = ${MAX_INTENT_OVERRIDE_CHARS};
-      function normalizeIntentOverrideInput(rawValue) {
-        if (typeof rawValue !== 'string') {
-          return undefined;
-        }
-
-        const normalized = rawValue
-          .replace(/\\r?\\n/g, ' ')
-          .replace(/\\s+/g, ' ')
-          .trim()
-          .slice(0, maxIntentOverrideChars);
-        return normalized || undefined;
-      }
-
-      document.addEventListener('change', (event) => {
-        const target = event.target;
-        if (!(target instanceof HTMLElement)) {
-          return;
-        }
-
-        const toggle = target.closest('[data-resume-path-toggle="true"]');
-        if (!(toggle instanceof HTMLInputElement)) {
-          return;
-        }
-
-        const stepId = toggle.dataset.resumePathStepId;
-        if (
-          stepId !== 'confirmIntent' &&
-          stepId !== 'runNextSafeAction' &&
-          stepId !== 'clearBlocker'
-        ) {
-          return;
-        }
-
-        vscode.postMessage({
-          type: 'resumePathToggle',
-          stepId,
-          completed: toggle.checked,
-        });
-      });
-
-      document.addEventListener('keydown', (event) => {
-        if (!(event.target instanceof HTMLInputElement)) {
-          return;
-        }
-
-        if (event.target.id !== 'intent-override-input') {
-          return;
-        }
-
-        if (event.key !== 'Enter') {
-          return;
-        }
-
-        event.preventDefault();
-        const intent = normalizeIntentOverrideInput(event.target.value);
-        if (!intent) {
-          return;
-        }
-
-        vscode.postMessage({
-          type: 'setIntentOverride',
-          intent,
-        });
-      });
-
-      document.addEventListener('click', (event) => {
-        const target = event.target;
-        if (!(target instanceof HTMLElement)) {
-          return;
-        }
-
-        const actionElement = target.closest('[data-action]');
-        if (actionElement instanceof HTMLElement) {
-          event.preventDefault();
-          const action = actionElement.dataset.action;
-          if (typeof action !== 'string' || !action) {
-            vscode.postMessage({ type: 'blockedLink' });
-            return;
-          }
-
-          if (action === 'toggleEvidenceMore') {
-            setEvidenceExpanded(!Boolean(viewState.evidenceExpanded));
-            return;
-          }
-
-          if (action === 'toggleTimeline') {
-            setTimelineExpanded(!Boolean(viewState.timelineExpanded));
-            return;
-          }
-
-          if (action === 'openEvidence') {
-            const evidenceId = actionElement.dataset.evidenceId?.trim();
-            if (!evidenceId) {
-              vscode.postMessage({ type: 'blockedLink' });
-              return;
-            }
-            vscode.postMessage({ type: 'openEvidence', evidenceId });
-            return;
-          }
-
-          if (action === 'openLink') {
-            const index = parseDatasetInteger(actionElement.dataset.linkIndex);
-            if (index === undefined) {
-              vscode.postMessage({ type: 'blockedLink' });
-              return;
-            }
-            vscode.postMessage({ type: 'openLink', index });
-            return;
-          }
-
-          if (action === 'openTopFile') {
-            const index = parseDatasetInteger(actionElement.dataset.topFileIndex);
-            if (index === undefined) {
-              vscode.postMessage({ type: 'blockedLink' });
-              return;
-            }
-            vscode.postMessage({ type: 'openTopFile', index });
-            return;
-          }
-
-          if (action === 'runNextStepAction') {
-            const stepIndex = parseDatasetInteger(actionElement.dataset.stepIndex);
-            if (stepIndex === undefined) {
-              vscode.postMessage({ type: 'blockedLink' });
-              return;
-            }
-            const primarySurface = actionElement.dataset.primaryNextSafeAction;
-            if (primarySurface === 'home' || primarySurface === 'recap') {
-              vscode.postMessage({ type: 'runNextStepAction', stepIndex, primarySurface });
-              return;
-            }
-            vscode.postMessage({ type: 'runNextStepAction', stepIndex });
-            return;
-          }
-
-          if (action === 'setIntentOverride') {
-            const input = document.getElementById('intent-override-input');
-            if (!(input instanceof HTMLInputElement)) {
-              return;
-            }
-
-            const intent = normalizeIntentOverrideInput(input.value);
-            if (!intent) {
-              input.focus();
-              return;
-            }
-            vscode.postMessage({ type: 'setIntentOverride', intent });
-            return;
-          }
-
-          if (hostActions.has(action)) {
-            vscode.postMessage({ type: action });
-            return;
-          }
-
-          vscode.postMessage({ type: 'blockedLink' });
-          return;
-        }
-
-        const anchor = target.closest('a');
-        if (anchor) {
-          event.preventDefault();
-          vscode.postMessage({ type: 'blockedLink' });
-        }
-      });
+${clientScript}
     </script>
   </body>
 </html>`;

--- a/src/webview/panelCards.ts
+++ b/src/webview/panelCards.ts
@@ -1,0 +1,183 @@
+import { escapeHtml } from '../webviewSecurity';
+
+export interface StatusCardInput {
+  sourceLabel: string;
+  generatedAtLabel: string;
+  statusHint: string;
+  autoSummaryStatusLabel: string;
+  autoSummaryStatusDetail: string;
+  autoSummaryToggleDisabledAttr: string;
+  autoSummaryToggleLabel: string;
+}
+
+export function renderStatusCard(input: StatusCardInput): string {
+  return `<div class="card">
+      <h3>Status</h3>
+      <div class="status-label">${escapeHtml(input.sourceLabel)} · ${escapeHtml(input.generatedAtLabel)}</div>
+      <div class="status-detail muted">${escapeHtml(input.statusHint)}</div>
+      <div class="status-detail"><strong>${escapeHtml(input.autoSummaryStatusLabel)}</strong></div>
+      <div class="status-detail muted">${escapeHtml(input.autoSummaryStatusDetail)}</div>
+      <div class="status-actions">
+        <button type="button" data-action="refreshSummary">Refresh summary now</button>
+        <button type="button" class="secondary" data-action="toggleAutoSummaries" ${
+          input.autoSummaryToggleDisabledAttr
+        }>${escapeHtml(input.autoSummaryToggleLabel)}</button>
+      </div>
+    </div>`;
+}
+
+export interface TrustCenterCardInput {
+  trustTrackingLabel: string;
+  storedLocallyLabel: string;
+  sentToAiLabel: string;
+  trustBasedOn: string;
+  trustCueDetailsTrustedHtml: string;
+  autoSummaryToggleDisabledAttr: string;
+  autoSummaryToggleLabel: string;
+}
+
+export function renderTrustCenterCard(input: TrustCenterCardInput): string {
+  return `<div class="card">
+      <h3>Trust Center</h3>
+      <div class="trust-row"><span class="trust-key">Tracking:</span> ${escapeHtml(input.trustTrackingLabel)}</div>
+      <div class="trust-row"><span class="trust-key">Stored locally:</span> ${escapeHtml(input.storedLocallyLabel)}</div>
+      <div class="trust-row"><span class="trust-key">Sent to AI:</span> ${escapeHtml(input.sentToAiLabel)}</div>
+      <div class="trust-row"><span class="trust-key">Based on:</span> ${escapeHtml(input.trustBasedOn)}</div>
+      <details>
+        <summary><strong>Why am I seeing this?</strong></summary>
+        <ul class="compact-list">${input.trustCueDetailsTrustedHtml || '<li>No evidence counts yet.</li>'}</ul>
+      </details>
+      <div class="status-actions">
+        <button type="button" class="secondary" data-action="toggleAutoSummaries" ${
+          input.autoSummaryToggleDisabledAttr
+        }>${escapeHtml(input.autoSummaryToggleLabel)}</button>
+        <button type="button" class="secondary" data-action="openPrivacySafety">Open Privacy & Safety</button>
+      </div>
+    </div>`;
+}
+
+export interface RecapCardInput {
+  recapDoneListTrustedHtml: string;
+  recapPendingListTrustedHtml: string;
+  recapFirstAction: string;
+  recapPrimaryNextActionButtonTrustedHtml: string;
+}
+
+export function renderRecapCard(input: RecapCardInput): string {
+  return `<div class="card recap-card">
+      <h3>Session Recap</h3>
+      <div class="recap-grid">
+        <section>
+          <h4>Done since last resume</h4>
+          <ul class="compact-list">${input.recapDoneListTrustedHtml || '<li>None captured yet.</li>'}</ul>
+        </section>
+        <section>
+          <h4>Pending / blocked</h4>
+          <ul class="compact-list">${input.recapPendingListTrustedHtml || '<li>No blocker captured.</li>'}</ul>
+        </section>
+        <section>
+          <h4>Next safe action</h4>
+          <p class="companion-primary">${escapeHtml(
+            input.recapFirstAction || 'Refresh summary to regenerate first-action guidance.',
+          )}</p>
+          <div class="status-actions">
+            ${input.recapPrimaryNextActionButtonTrustedHtml}
+            <button type="button" class="secondary" data-action="copyNextSteps">Copy next steps</button>
+            <button type="button" class="secondary" data-action="sessionAddCheckpoint">Add note</button>
+            <button type="button" class="secondary" data-action="checkpointOpenList">List notes</button>
+          </div>
+        </section>
+      </div>
+    </div>`;
+}
+
+export function renderChangesSinceCard(changesSinceItemsTrustedHtml: string): string {
+  return `<div class="card">
+      <h3>Changes Since Last Time</h3>
+      <ul class="compact-list">${changesSinceItemsTrustedHtml || '<li>No changes captured.</li>'}</ul>
+    </div>`;
+}
+
+export interface TimelineCardInput {
+  showTimeline: boolean;
+  timelineGroupsTrustedHtml: string;
+}
+
+export function renderTimelineCard(input: TimelineCardInput): string {
+  if (!input.showTimeline) {
+    return '';
+  }
+
+  return `<div class="card">
+      <h3>Timeline</h3>
+      <button type="button" class="secondary" data-action="toggleTimeline" aria-expanded="false" aria-controls="timeline-content">Show timeline</button>
+      <div id="timeline-content" hidden>
+        ${input.timelineGroupsTrustedHtml || '<p class="muted">No timeline entries captured yet.</p>'}
+      </div>
+    </div>`;
+}
+
+export interface TitledListCardInput {
+  title: string;
+  listItemsTrustedHtml: string;
+  emptyMessage: string;
+  listClassName?: string;
+}
+
+export function renderTitledListCard(input: TitledListCardInput): string {
+  const listClass = input.listClassName ? ` class="${escapeHtml(input.listClassName)}"` : '';
+  return `<div class="card">
+      <h3>${escapeHtml(input.title)}</h3>
+      <ul${listClass}>${input.listItemsTrustedHtml || `<li>${escapeHtml(input.emptyMessage)}</li>`}</ul>
+    </div>`;
+}
+
+export function renderQuickActionsCard(quickActionGroupsTrustedHtml: string): string {
+  return `<div class="card">
+      <h3>Quick Actions</h3>
+      ${quickActionGroupsTrustedHtml}
+    </div>`;
+}
+
+export function renderRestorePackCard(
+  restorePackGroupsTrustedHtml: string,
+  trustedWorkspace: boolean,
+): string {
+  return `<div class="card">
+      <h3>Restore Pack</h3>
+      ${restorePackGroupsTrustedHtml}
+      ${
+        trustedWorkspace
+          ? ''
+          : '<div class="restore-note">Restricted Mode: task/debug/branch execution actions are disabled.</div>'
+      }
+    </div>`;
+}
+
+export interface EvidenceCardInput {
+  evidenceItemsTrustedHtml: string;
+  hasExtraEvidence: boolean;
+}
+
+export function renderEvidenceCard(input: EvidenceCardInput): string {
+  return `<div class="card">
+      <details>
+        <summary><strong>Evidence</strong></summary>
+        <ul class="evidence-list" id="evidence-list">${
+          input.evidenceItemsTrustedHtml || '<li>None captured</li>'
+        }</ul>
+        ${
+          input.hasExtraEvidence
+            ? '<button type="button" class="show-more-btn" data-action="toggleEvidenceMore">Show more</button>'
+            : ''
+        }
+      </details>
+    </div>`;
+}
+
+export function renderDetailsCard(detailsTrustedHtml: string): string {
+  return `<div class="card">
+      <h3>Details</h3>
+      <div class="details-markdown">${detailsTrustedHtml}</div>
+    </div>`;
+}

--- a/src/webview/panelClientScript.ts
+++ b/src/webview/panelClientScript.ts
@@ -1,0 +1,264 @@
+export function renderPanelClientScript(maxIntentOverrideChars: number): string {
+  return `
+      const vscode = acquireVsCodeApi();
+      const hostActions = new Set([
+        'fixSummary',
+        'checkpointPinToggle',
+        'checkpointMarkDone',
+        'checkpointDismiss',
+        'checkpointOpenList',
+        'openScratchpad',
+        'appendScratchpad',
+        'setScratchpadScope',
+        'sessionAddCheckpoint',
+        'setIntentOverride',
+        'clearIntentOverride',
+        'copyNextSteps',
+        'copySummary',
+        'copyPromptAndOpenCodex',
+        'refreshSummary',
+        'toggleAutoSummaries',
+        'acknowledgeNudge',
+        'dismissNudge',
+        'openPrivacySafety',
+        'rateHelpfulness',
+        'runNextStepAction',
+        'restoreWorkingSet',
+        'restoreJumpToLastEdit',
+        'restoreReopenFiles',
+        'restoreOpenChangedFiles',
+        'restoreRerunTask',
+        'restoreRerunDebug',
+        'restoreOpenProblems',
+        'restoreOpenDiagnosticFile',
+        'restoreCheckoutPreviousBranch',
+        'restoreCopyFailingCommand'
+      ]);
+      const viewState = Object.assign(
+        { evidenceExpanded: false, timelineExpanded: false },
+        vscode.getState() || {},
+      );
+
+      function persistViewState() {
+        vscode.setState(viewState);
+      }
+
+      function setEvidenceExpanded(expanded) {
+        const list = document.getElementById('evidence-list');
+        const toggle = document.querySelector('[data-action="toggleEvidenceMore"]');
+        if (!(list instanceof HTMLElement) || !(toggle instanceof HTMLElement)) {
+          viewState.evidenceExpanded = false;
+          persistViewState();
+          return;
+        }
+
+        list.classList.toggle('show-more', expanded);
+        toggle.textContent = expanded ? 'Show less' : 'Show more';
+        viewState.evidenceExpanded = expanded;
+        persistViewState();
+      }
+
+      function setTimelineExpanded(expanded) {
+        const timeline = document.getElementById('timeline-content');
+        const toggle = document.querySelector('[data-action="toggleTimeline"]');
+        if (!(timeline instanceof HTMLElement) || !(toggle instanceof HTMLElement)) {
+          viewState.timelineExpanded = false;
+          persistViewState();
+          return;
+        }
+
+        if (expanded) {
+          timeline.removeAttribute('hidden');
+          toggle.textContent = 'Hide timeline';
+          toggle.setAttribute('aria-expanded', 'true');
+        } else {
+          timeline.setAttribute('hidden', 'true');
+          toggle.textContent = 'Show timeline';
+          toggle.setAttribute('aria-expanded', 'false');
+        }
+        viewState.timelineExpanded = expanded;
+        persistViewState();
+      }
+
+      setEvidenceExpanded(Boolean(viewState.evidenceExpanded));
+      setTimelineExpanded(Boolean(viewState.timelineExpanded));
+
+      function parseDatasetInteger(rawValue) {
+        if (typeof rawValue !== 'string') {
+          return undefined;
+        }
+        const parsed = Number(rawValue);
+        if (!Number.isInteger(parsed) || parsed < 0) {
+          return undefined;
+        }
+        return parsed;
+      }
+
+      const maxIntentOverrideChars = ${maxIntentOverrideChars};
+      function normalizeIntentOverrideInput(rawValue) {
+        if (typeof rawValue !== 'string') {
+          return undefined;
+        }
+
+        const normalized = rawValue
+          .replace(/\\r?\\n/g, ' ')
+          .replace(/\\s+/g, ' ')
+          .trim()
+          .slice(0, maxIntentOverrideChars);
+        return normalized || undefined;
+      }
+
+      document.addEventListener('change', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+          return;
+        }
+
+        const toggle = target.closest('[data-resume-path-toggle="true"]');
+        if (!(toggle instanceof HTMLInputElement)) {
+          return;
+        }
+
+        const stepId = toggle.dataset.resumePathStepId;
+        if (
+          stepId !== 'confirmIntent' &&
+          stepId !== 'runNextSafeAction' &&
+          stepId !== 'clearBlocker'
+        ) {
+          return;
+        }
+
+        vscode.postMessage({
+          type: 'resumePathToggle',
+          stepId,
+          completed: toggle.checked,
+        });
+      });
+
+      document.addEventListener('keydown', (event) => {
+        if (!(event.target instanceof HTMLInputElement)) {
+          return;
+        }
+
+        if (event.target.id !== 'intent-override-input') {
+          return;
+        }
+
+        if (event.key !== 'Enter') {
+          return;
+        }
+
+        event.preventDefault();
+        const intent = normalizeIntentOverrideInput(event.target.value);
+        if (!intent) {
+          return;
+        }
+
+        vscode.postMessage({
+          type: 'setIntentOverride',
+          intent,
+        });
+      });
+
+      document.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof HTMLElement)) {
+          return;
+        }
+
+        const actionElement = target.closest('[data-action]');
+        if (actionElement instanceof HTMLElement) {
+          event.preventDefault();
+          const action = actionElement.dataset.action;
+          if (typeof action !== 'string' || !action) {
+            vscode.postMessage({ type: 'blockedLink' });
+            return;
+          }
+
+          if (action === 'toggleEvidenceMore') {
+            setEvidenceExpanded(!Boolean(viewState.evidenceExpanded));
+            return;
+          }
+
+          if (action === 'toggleTimeline') {
+            setTimelineExpanded(!Boolean(viewState.timelineExpanded));
+            return;
+          }
+
+          if (action === 'openEvidence') {
+            const evidenceId = actionElement.dataset.evidenceId?.trim();
+            if (!evidenceId) {
+              vscode.postMessage({ type: 'blockedLink' });
+              return;
+            }
+            vscode.postMessage({ type: 'openEvidence', evidenceId });
+            return;
+          }
+
+          if (action === 'openLink') {
+            const index = parseDatasetInteger(actionElement.dataset.linkIndex);
+            if (index === undefined) {
+              vscode.postMessage({ type: 'blockedLink' });
+              return;
+            }
+            vscode.postMessage({ type: 'openLink', index });
+            return;
+          }
+
+          if (action === 'openTopFile') {
+            const index = parseDatasetInteger(actionElement.dataset.topFileIndex);
+            if (index === undefined) {
+              vscode.postMessage({ type: 'blockedLink' });
+              return;
+            }
+            vscode.postMessage({ type: 'openTopFile', index });
+            return;
+          }
+
+          if (action === 'runNextStepAction') {
+            const stepIndex = parseDatasetInteger(actionElement.dataset.stepIndex);
+            if (stepIndex === undefined) {
+              vscode.postMessage({ type: 'blockedLink' });
+              return;
+            }
+            const primarySurface = actionElement.dataset.primaryNextSafeAction;
+            if (primarySurface === 'home' || primarySurface === 'recap') {
+              vscode.postMessage({ type: 'runNextStepAction', stepIndex, primarySurface });
+              return;
+            }
+            vscode.postMessage({ type: 'runNextStepAction', stepIndex });
+            return;
+          }
+
+          if (action === 'setIntentOverride') {
+            const input = document.getElementById('intent-override-input');
+            if (!(input instanceof HTMLInputElement)) {
+              return;
+            }
+
+            const intent = normalizeIntentOverrideInput(input.value);
+            if (!intent) {
+              input.focus();
+              return;
+            }
+            vscode.postMessage({ type: 'setIntentOverride', intent });
+            return;
+          }
+
+          if (hostActions.has(action)) {
+            vscode.postMessage({ type: action });
+            return;
+          }
+
+          vscode.postMessage({ type: 'blockedLink' });
+          return;
+        }
+
+        const anchor = target.closest('a');
+        if (anchor) {
+          event.preventDefault();
+          vscode.postMessage({ type: 'blockedLink' });
+        }
+      });
+`;
+}

--- a/src/webview/panelStyles.ts
+++ b/src/webview/panelStyles.ts
@@ -1,0 +1,344 @@
+export const PANEL_WEBVIEW_STYLE = `
+      :root {
+        --surface-bg: var(--vscode-editorWidget-background);
+        --surface-border: var(--vscode-panel-border);
+        --surface-muted: var(--vscode-descriptionForeground);
+        --surface-strong: var(--vscode-foreground);
+        --accent: var(--vscode-focusBorder);
+      }
+      body {
+        color: var(--surface-strong);
+        background: var(--vscode-editor-background);
+        font-family: var(--vscode-font-family);
+        font-size: var(--vscode-font-size);
+        line-height: 1.5;
+        padding: 16px;
+      }
+      .card {
+        border: 1px solid var(--surface-border);
+        border-radius: 12px;
+        padding: 14px;
+        margin-bottom: 14px;
+        background: var(--surface-bg);
+      }
+      ul {
+        padding-left: 20px;
+      }
+      h3 {
+        margin-top: 0;
+        margin-bottom: 10px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      h3::before {
+        content: '';
+        width: 8px;
+        height: 8px;
+        border-radius: 999px;
+        background: var(--accent);
+      }
+      h4 {
+        margin-bottom: 8px;
+      }
+      a {
+        color: var(--vscode-textLink-foreground);
+      }
+      a:hover {
+        color: var(--vscode-textLink-activeForeground);
+      }
+      pre {
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .details-markdown {
+        line-height: 1.45;
+      }
+      .details-markdown > :first-child {
+        margin-top: 0;
+      }
+      .details-markdown > :last-child {
+        margin-bottom: 0;
+      }
+      .details-markdown p,
+      .details-markdown li {
+        overflow-wrap: anywhere;
+      }
+      .details-markdown code {
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', monospace;
+      }
+      .kind {
+        color: var(--vscode-descriptionForeground);
+      }
+      .mode {
+        color: var(--vscode-descriptionForeground);
+        font-size: 13px;
+      }
+      .status-label {
+        font-weight: 700;
+        font-size: 13px;
+      }
+      .status-detail {
+        margin-top: 6px;
+      }
+      .status-actions {
+        margin-top: 10px;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .step-evidence {
+        margin-top: 6px;
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+      }
+      .step-actions {
+        margin-top: 8px;
+      }
+      .step-action {
+        padding: 4px 10px;
+        font-size: 12px;
+      }
+      .step-advisory {
+        margin-top: 6px;
+        font-size: 12px;
+      }
+      .badge {
+        display: inline-block;
+        border: 1px solid var(--vscode-widget-border);
+        border-radius: 999px;
+        padding: 2px 8px;
+        font-size: 12px;
+        text-decoration: none;
+        color: inherit;
+      }
+      .badge.clickable {
+        cursor: pointer;
+      }
+      .badge.kind-url {
+        border-color: var(--vscode-textLink-foreground);
+      }
+      .badge.kind-file {
+        border-color: var(--vscode-charts-green);
+      }
+      .evidence-kind {
+        color: var(--vscode-descriptionForeground);
+      }
+      .evidence-target {
+        color: var(--vscode-descriptionForeground);
+      }
+      .extra-evidence {
+        display: none;
+      }
+      .evidence-list.show-more .extra-evidence {
+        display: list-item;
+      }
+      details summary {
+        cursor: pointer;
+      }
+      .show-more-btn {
+        margin-top: 8px;
+      }
+      .muted {
+        color: var(--surface-muted);
+      }
+      .resume-path-list {
+        margin-top: 10px;
+      }
+      .resume-path-item {
+        margin-bottom: 8px;
+      }
+      .resume-path-toggle {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        cursor: pointer;
+        font-weight: 600;
+      }
+      .resume-path-toggle input[type='checkbox'] {
+        width: 14px;
+        height: 14px;
+      }
+      .resume-path-detail {
+        margin: 4px 0 0 22px;
+        font-size: 12px;
+      }
+      .blocker-disabled-reason {
+        margin-top: 8px;
+      }
+      .restore-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+        gap: 8px;
+      }
+      button {
+        border: 1px solid var(--vscode-button-border, transparent);
+        background: var(--vscode-button-background);
+        color: var(--vscode-button-foreground);
+        border-radius: 8px;
+        padding: 8px 10px;
+      }
+      button:focus-visible {
+        outline: 2px solid var(--vscode-focusBorder);
+        outline-offset: 2px;
+      }
+      button.secondary {
+        background: transparent;
+        color: var(--vscode-editor-foreground);
+        border-color: var(--vscode-widget-border);
+      }
+      .restore-grid button {
+        text-align: left;
+        cursor: pointer;
+      }
+      .restore-grid button:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+      .restore-note {
+        color: var(--vscode-descriptionForeground);
+        font-size: 12px;
+        margin-top: 8px;
+      }
+      .note-actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+      .note-actions button {
+        border-radius: 6px;
+        padding: 6px 10px;
+        cursor: pointer;
+      }
+      .timeline-group ul {
+        margin-top: 0;
+      }
+      .timeline-group li {
+        display: grid;
+        grid-template-columns: 70px 1fr;
+        gap: 8px;
+        margin-bottom: 6px;
+      }
+      .timeline-time {
+        color: var(--vscode-descriptionForeground);
+        font-size: 12px;
+        padding-top: 2px;
+      }
+      .timeline-row {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+      .timeline-detail {
+        color: var(--vscode-descriptionForeground);
+        font-size: 12px;
+        overflow-wrap: anywhere;
+      }
+      .quick-actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+      }
+      .quick-actions button {
+        min-width: 160px;
+      }
+      .action-group + .action-group {
+        margin-top: 10px;
+      }
+      .action-group h4,
+      .action-group h5 {
+        margin: 0 0 8px 0;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--surface-muted);
+      }
+      .companion-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 12px;
+      }
+      .companion-block {
+        border: 1px solid var(--vscode-widget-border);
+        border-radius: 10px;
+        padding: 12px;
+        background: var(--vscode-editor-background);
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+      }
+      .companion-block h4 {
+        margin-top: 0;
+        margin-bottom: 6px;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        color: var(--surface-muted);
+      }
+      .companion-primary {
+        margin: 0 0 8px 0;
+        font-weight: 700;
+        line-height: 1.4;
+      }
+      .companion-kicker {
+        margin: 0;
+        font-size: 12px;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--surface-muted);
+      }
+      .companion-meta {
+        margin: 0;
+        color: var(--surface-muted);
+      }
+      .intent-editor {
+        border: 1px solid var(--vscode-widget-border);
+        border-radius: 8px;
+        padding: 8px;
+      }
+      .intent-editor-row {
+        margin-top: 6px;
+      }
+      .intent-editor input[type='text'] {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 6px 8px;
+        border-radius: 6px;
+        border: 1px solid var(--vscode-input-border, var(--vscode-widget-border));
+        background: var(--vscode-input-background);
+        color: var(--vscode-input-foreground);
+      }
+      .intent-editor-actions {
+        display: flex;
+        gap: 8px;
+        margin-top: 8px;
+        flex-wrap: wrap;
+      }
+      .compact-list {
+        margin: 0 0 10px 0;
+        padding-left: 18px;
+      }
+      .companion-restore-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 6px;
+      }
+      .companion-restore-grid button {
+        text-align: left;
+      }
+      .trust-row {
+        margin-bottom: 8px;
+      }
+      .trust-key {
+        font-weight: 600;
+      }
+      .recap-card .recap-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 10px;
+      }
+      .recap-card h4 {
+        margin-top: 0;
+      }
+`;

--- a/test/panelCards.test.ts
+++ b/test/panelCards.test.ts
@@ -1,0 +1,86 @@
+import {
+  renderChangesSinceCard,
+  renderDetailsCard,
+  renderEvidenceCard,
+  renderQuickActionsCard,
+  renderRecapCard,
+  renderRestorePackCard,
+  renderStatusCard,
+  renderTimelineCard,
+  renderTitledListCard,
+  renderTrustCenterCard,
+} from '../src/webview/panelCards';
+
+describe('panelCards', () => {
+  it('renders status and trust cards with expected controls', () => {
+    const status = renderStatusCard({
+      sourceLabel: 'Local summary (instant)',
+      generatedAtLabel: '10:12',
+      statusHint: 'Running local-only summary.',
+      autoSummaryStatusLabel: 'Auto summaries active',
+      autoSummaryStatusDetail: 'Runs on focus after idle and cooldown checks.',
+      autoSummaryToggleDisabledAttr: '',
+      autoSummaryToggleLabel: 'Pause auto summaries',
+    });
+    const trust = renderTrustCenterCard({
+      trustTrackingLabel: 'on',
+      storedLocallyLabel: 'Redacted local data only',
+      sentToAiLabel: 'Nothing (local-only mode).',
+      trustBasedOn: 'Evidence from local signals',
+      trustCueDetailsTrustedHtml: '<li>Recent files: 2</li>',
+      autoSummaryToggleDisabledAttr: '',
+      autoSummaryToggleLabel: 'Pause auto summaries',
+    });
+
+    expect(status).toContain('<h3>Status</h3>');
+    expect(status).toContain('data-action="refreshSummary"');
+    expect(trust).toContain('<h3>Trust Center</h3>');
+    expect(trust).toContain('data-action="openPrivacySafety"');
+    expect(trust).toContain('<li>Recent files: 2</li>');
+  });
+
+  it('renders timeline/list/evidence/details sections with expected fallbacks', () => {
+    const timeline = renderTimelineCard({
+      showTimeline: true,
+      timelineGroupsTrustedHtml: '',
+    });
+    const list = renderTitledListCard({
+      title: 'Top Files',
+      listItemsTrustedHtml: '',
+      emptyMessage: 'None captured',
+    });
+    const evidence = renderEvidenceCard({
+      evidenceItemsTrustedHtml: '',
+      hasExtraEvidence: true,
+    });
+    const details = renderDetailsCard('<p>Summary</p>');
+
+    expect(timeline).toContain('data-action="toggleTimeline"');
+    expect(timeline).toContain('No timeline entries captured yet.');
+    expect(list).toContain('<h3>Top Files</h3>');
+    expect(list).toContain('<li>None captured</li>');
+    expect(evidence).toContain('data-action="toggleEvidenceMore"');
+    expect(details).toContain('<div class="details-markdown"><p>Summary</p></div>');
+  });
+
+  it('renders recap, quick actions, restore pack, and changes cards', () => {
+    const recap = renderRecapCard({
+      recapDoneListTrustedHtml: '<li>Ran verify</li>',
+      recapPendingListTrustedHtml: '<li>Fix blocker</li>',
+      recapFirstAction: 'Open src/extension.ts',
+      recapPrimaryNextActionButtonTrustedHtml:
+        '<button type="button" data-primary-next-safe-action="recap" data-action="runNextStepAction" data-step-index="0">Open file</button>',
+    });
+    const quickActions = renderQuickActionsCard(
+      '<div class="quick-actions"><button>Copy summary</button></div>',
+    );
+    const restore = renderRestorePackCard('<section>restore buttons</section>', false);
+    const changes = renderChangesSinceCard('<li>Diffstat: 1 file changed</li>');
+
+    expect(recap).toContain('<h3>Session Recap</h3>');
+    expect(recap).toContain('data-action="copyNextSteps"');
+    expect(quickActions).toContain('<h3>Quick Actions</h3>');
+    expect(restore).toContain('Restricted Mode: task/debug/branch execution actions are disabled.');
+    expect(changes).toContain('<h3>Changes Since Last Time</h3>');
+  });
+});

--- a/test/panelClientScript.test.ts
+++ b/test/panelClientScript.test.ts
@@ -1,0 +1,13 @@
+import { renderPanelClientScript } from '../src/webview/panelClientScript';
+
+describe('renderPanelClientScript', () => {
+  it('includes expected host action allowlist and intent max-length binding', () => {
+    const script = renderPanelClientScript(280);
+
+    expect(script).toContain("'restoreWorkingSet'");
+    expect(script).toContain("'setIntentOverride'");
+    expect(script).toContain("'clearIntentOverride'");
+    expect(script).toContain('const maxIntentOverrideChars = 280;');
+    expect(script).toContain("type: 'blockedLink'");
+  });
+});


### PR DESCRIPTION
## Summary
Refactors the large `renderWebview` path into composable `src/webview/*` modules without intentional user-visible behavior changes.

## Goal Card

- User pain this change addresses: UX iteration in `renderWebview` was high-risk because layout, style, and action wiring were tightly coupled in one very large function.
- Expected user outcome: No behavior change, but faster and safer follow-on UX improvements with lower regression risk.
- Success metric (how we know this worked): Existing integration/manual flows remain unchanged while extension-side render complexity is reduced in `src/extension.ts`.
- Non-goals: No copy/interaction redesign, no new telemetry, no allowlist/CSP policy changes.

## What changed
- Added modular webview renderer files:
  - `src/webview/panelCards.ts` (status/trust/recap/timeline/list/quick actions/restore/evidence/details cards)
  - `src/webview/panelStyles.ts` (shared panel CSS block)
  - `src/webview/panelClientScript.ts` (client-side message/action wiring script)
- Updated `src/extension.ts` render orchestration to compose panel output from those modules.
- Preserved existing action ids, blocked-link handling, CSP usage, and message routing behavior.
- Added module-level regression tests:
  - `test/panelCards.test.ts`
  - `test/panelClientScript.test.ts`

## Why (cognitive rationale)
Reliable cue/action presentation is essential for interruption recovery. This refactor reduces implementation coupling so we can iterate on cue quality and timing with lower regression risk while preserving current behavior.

## How tested
- `npm run verify:quick`
- `npm run test:integration`
- `npm run verify`

## How to verify manually
1. Run `TaCoS: Show Resume Brief Now`.
2. Confirm `Companion Home`, `Session Recap`, `Resume Path`, `Trust Center`, `Timeline`, and `Evidence` render as before.
3. Validate top actions still work (`Refresh`, `Copy next steps`, `Copy summary`, `Restore working set`, `Open evidence/file/link`).
4. Confirm blocked links still show guarded behavior.
5. Confirm timeline/evidence show-more toggles still persist state.
6. Confirm inline intent save/reset and resume-path checkbox interactions still work.

## Performance impact notes
- No new heavy work on focus path.
- Refactor is mostly code movement + composition; rendering logic remains equivalent.
- No new network calls and no telemetry changes.

## Checklist

- [x] I completed the Goal Card above.
- [x] I updated docs for any behavior/configuration changes (`README.md`, `docs/*` as needed).
- [x] I reviewed UX friction for this change (notifications, forced clicks, interruption cost).
- [x] I added or updated regression tests for new behavior and settings toggles.
- [x] I ran `npm run compile`, `npm run lint`, and `npm test`.
- [x] I ran `npm run test:integration` or documented why it was skipped.
- [x] I noted any metric impact (or no-impact) for weekly product review.
