### PR TITLE
v0.6.1: Add keyboard shortcuts for top resume actions (fixes #152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ TaCoS is built around five non-negotiable principles:
 - `TaCoS: Copy Metrics Baseline Snapshot`
 - `TaCoS: Copy Diagnostics`
 
+## Keyboard Shortcuts (Default Chords)
+
+These low-conflict defaults speed up the top resume actions without overriding common single-key editor shortcuts. You can override any of them in VS Code Keyboard Shortcuts.
+
+| Action                     | Windows/Linux                   | macOS                         |
+| -------------------------- | ------------------------------- | ----------------------------- |
+| Show Resume Brief Now      | `Ctrl+Alt+T`, then `Ctrl+Alt+S` | `Cmd+Alt+T`, then `Cmd+Alt+S` |
+| Copy Prompt and Open Codex | `Ctrl+Alt+T`, then `Ctrl+Alt+P` | `Cmd+Alt+T`, then `Cmd+Alt+P` |
+| Add Quick Checkpoint Note  | `Ctrl+Alt+T`, then `Ctrl+Alt+K` | `Cmd+Alt+T`, then `Cmd+Alt+K` |
+| Jump to Last Edit          | `Ctrl+Alt+T`, then `Ctrl+Alt+J` | `Cmd+Alt+T`, then `Cmd+Alt+J` |
+| Restore Working Set        | `Ctrl+Alt+T`, then `Ctrl+Alt+R` | `Cmd+Alt+T`, then `Cmd+Alt+R` |
+
 ### Codex / ChatGPT Interop
 
 `TaCoS: Copy Prompt and Open Codex` now tries known OpenAI ChatGPT extension commands first:

--- a/package.json
+++ b/package.json
@@ -261,6 +261,38 @@
         "title": "TaCoS: Clear OpenAI API Key"
       }
     ],
+    "keybindings": [
+      {
+        "command": "tacos.showNow",
+        "key": "ctrl+alt+t ctrl+alt+s",
+        "mac": "cmd+alt+t cmd+alt+s",
+        "when": "workbenchState != empty"
+      },
+      {
+        "command": "tacos.copyPromptAndOpenCodex",
+        "key": "ctrl+alt+t ctrl+alt+p",
+        "mac": "cmd+alt+t cmd+alt+p",
+        "when": "workbenchState != empty"
+      },
+      {
+        "command": "tacos.addQuickCheckpointNote",
+        "key": "ctrl+alt+t ctrl+alt+k",
+        "mac": "cmd+alt+t cmd+alt+k",
+        "when": "workbenchState != empty"
+      },
+      {
+        "command": "tacos.jumpToLastEdit",
+        "key": "ctrl+alt+t ctrl+alt+j",
+        "mac": "cmd+alt+t cmd+alt+j",
+        "when": "workbenchState != empty"
+      },
+      {
+        "command": "tacos.restoreWorkingSet",
+        "key": "ctrl+alt+t ctrl+alt+r",
+        "mac": "cmd+alt+t cmd+alt+r",
+        "when": "workbenchState != empty"
+      }
+    ],
     "configuration": {
       "title": "TaCoS",
       "properties": {

--- a/test/keybindings.test.ts
+++ b/test/keybindings.test.ts
@@ -1,0 +1,73 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+interface KeybindingContribution {
+  command: string;
+  key: string;
+  mac?: string;
+  when?: string;
+}
+
+interface ExtensionPackageJson {
+  contributes?: {
+    keybindings?: KeybindingContribution[];
+  };
+}
+
+function getKeybindings(): KeybindingContribution[] {
+  const packageJsonPath = path.resolve(__dirname, '..', 'package.json');
+  const raw = fs.readFileSync(packageJsonPath, 'utf8');
+  const parsed = JSON.parse(raw) as ExtensionPackageJson;
+  return parsed.contributes?.keybindings ?? [];
+}
+
+describe('package keybinding contributions', () => {
+  it('declares low-conflict shortcuts for the top resume actions', () => {
+    const keybindings = getKeybindings();
+    const byCommand = new Map(keybindings.map((item) => [item.command, item]));
+
+    expect(byCommand.get('tacos.showNow')).toMatchObject({
+      key: 'ctrl+alt+t ctrl+alt+s',
+      mac: 'cmd+alt+t cmd+alt+s',
+      when: 'workbenchState != empty',
+    });
+    expect(byCommand.get('tacos.copyPromptAndOpenCodex')).toMatchObject({
+      key: 'ctrl+alt+t ctrl+alt+p',
+      mac: 'cmd+alt+t cmd+alt+p',
+      when: 'workbenchState != empty',
+    });
+    expect(byCommand.get('tacos.addQuickCheckpointNote')).toMatchObject({
+      key: 'ctrl+alt+t ctrl+alt+k',
+      mac: 'cmd+alt+t cmd+alt+k',
+      when: 'workbenchState != empty',
+    });
+    expect(byCommand.get('tacos.jumpToLastEdit')).toMatchObject({
+      key: 'ctrl+alt+t ctrl+alt+j',
+      mac: 'cmd+alt+t cmd+alt+j',
+      when: 'workbenchState != empty',
+    });
+    expect(byCommand.get('tacos.restoreWorkingSet')).toMatchObject({
+      key: 'ctrl+alt+t ctrl+alt+r',
+      mac: 'cmd+alt+t cmd+alt+r',
+      when: 'workbenchState != empty',
+    });
+  });
+
+  it('uses a shared TaCoS prefix chord to minimize default conflicts', () => {
+    const keybindings = getKeybindings().filter((binding) =>
+      [
+        'tacos.showNow',
+        'tacos.copyPromptAndOpenCodex',
+        'tacos.addQuickCheckpointNote',
+        'tacos.jumpToLastEdit',
+        'tacos.restoreWorkingSet',
+      ].includes(binding.command),
+    );
+
+    expect(keybindings).toHaveLength(5);
+    for (const binding of keybindings) {
+      expect(binding.key.startsWith('ctrl+alt+t ')).toBe(true);
+      expect((binding.mac ?? '').startsWith('cmd+alt+t ')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What changed
- Added default keybinding contributions for top resume actions in `package.json`:
  - `tacos.showNow`
  - `tacos.copyPromptAndOpenCodex`
  - `tacos.addQuickCheckpointNote`
  - `tacos.jumpToLastEdit`
  - `tacos.restoreWorkingSet`
- Used conservative two-chord defaults with a shared TaCoS prefix (`Ctrl/Cmd+Alt+T`) to reduce collisions.
- Added a README `Keyboard Shortcuts` section documenting Windows/Linux and macOS defaults.
- Added `test/keybindings.test.ts` to assert keybinding contributions exist and keep the low-conflict prefix convention stable.

## Why (cognitive rationale)
- Faster access to a single next action reduces interruption recovery overhead by lowering command palette friction.
- Chorded shortcuts preserve a quiet, non-intrusive UX while enabling rapid execution for experienced users.
- Keeping these actions keyboard-first supports the v0.6 goal of shorter first-action lag without adding prompts or focus hijacking.

## How tested
- `npm test -- keybindings.test.ts`
- `npm run verify:quick`

## How to verify manually
1. Open a workspace folder.
2. Press `Ctrl+Alt+T`, then `Ctrl+Alt+S` (or macOS `Cmd+Alt+T`, then `Cmd+Alt+S`) and confirm Resume Brief opens.
3. Repeat for:
   - `... + P` => Copy Prompt + Open Codex
   - `... + K` => Add Quick Checkpoint Note
   - `... + J` => Jump to Last Edit
   - `... + R` => Restore Working Set
4. Confirm commands remain available via Command Palette and status bar quick actions.
5. Open Keyboard Shortcuts UI and confirm all five defaults can be overridden normally.

## Performance impact notes
- No runtime hot-path logic changes.
- Static contribution + docs/test updates only.
- No additional telemetry and no network behavior changes; local-only posture remains unchanged.
