### PR TITLE
v0.6.1: Demo mode should disable feedback actions to remain side-effect free (fixes #186)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -218,6 +218,7 @@ const NOISE_BUDGET_BLOCK_NUDGE_AFTER_SUMMARY_MS = 5 * 60_000;
 const NOISE_BUDGET_BLOCK_NUDGE_AFTER_CHECKPOINT_MS = 3 * 60_000;
 const NOISE_BUDGET_BLOCK_CHECKPOINT_AFTER_SUMMARY_MS = 5 * 60_000;
 const DEMO_MODE_IGNORED_WEBVIEW_MESSAGE_TYPES = new Set<WebviewMessage['type']>([
+  'fixSummary',
   'setPanelSectionExpanded',
   'sessionAddCheckpoint',
   'checkpointOpenList',
@@ -243,6 +244,7 @@ const DEMO_MODE_IGNORED_WEBVIEW_MESSAGE_TYPES = new Set<WebviewMessage['type']>(
   'restoreOpenDiagnosticFile',
   'restoreCheckoutPreviousBranch',
   'restoreCopyFailingCommand',
+  'rateHelpfulness',
 ]);
 const MAX_CHECKPOINT_NOTES_PER_SCOPE = 50;
 const MAX_NUDGE_FEEDBACK_ENTRIES_PER_SCOPE = 40;
@@ -696,6 +698,10 @@ export function activate(context: vscode.ExtensionContext): void {
       const hasDisabledListNotesAction = /data-action="checkpointOpenList"[^>]*disabled/u.test(
         panelHtml,
       );
+      const hasDisabledRateHelpfulnessAction = /data-action="rateHelpfulness"[^>]*disabled/u.test(
+        panelHtml,
+      );
+      const hasDisabledFixSummaryAction = /data-action="fixSummary"[^>]*disabled/u.test(panelHtml);
       const disabledResumePathToggleCount = (
         panelHtml.match(/<input[^>]*data-resume-path-toggle="true"[^>]*disabled/gu) ?? []
       ).length;
@@ -766,6 +772,8 @@ export function activate(context: vscode.ExtensionContext): void {
         hasDisabledRestoreRerunDebug,
         hasDisabledAddNoteAction,
         hasDisabledListNotesAction,
+        hasDisabledRateHelpfulnessAction,
+        hasDisabledFixSummaryAction,
       };
     }),
     vscode.commands.registerCommand('tacos.__test.getResumePathSnapshot', async () => {
@@ -4257,8 +4265,8 @@ function renderWebview(
         buttonsTrustedHtml: [
           `<button type="button" class="secondary" data-action="sessionAddCheckpoint" ${demoDisabledAttr}>Add note</button>`,
           `<button type="button" class="secondary" data-action="checkpointOpenList" ${demoDisabledAttr}>List notes</button>`,
-          '<button type="button" data-action="rateHelpfulness">Rate helpfulness</button>',
-          '<button type="button" class="secondary" data-action="fixSummary">Fix summary</button>',
+          `<button type="button" data-action="rateHelpfulness" ${demoDisabledAttr}>Rate helpfulness</button>`,
+          `<button type="button" class="secondary" data-action="fixSummary" ${demoDisabledAttr}>Fix summary</button>`,
         ],
       },
     ],

--- a/test/integration/suite/demoResumeCard.js
+++ b/test/integration/suite/demoResumeCard.js
@@ -75,6 +75,16 @@ async function run() {
     true,
     'Expected List notes quick action to be disabled in demo mode.',
   );
+  assert.equal(
+    resumeFlow?.hasDisabledRateHelpfulnessAction,
+    true,
+    'Expected Rate helpfulness quick action to be disabled in demo mode.',
+  );
+  assert.equal(
+    resumeFlow?.hasDisabledFixSummaryAction,
+    true,
+    'Expected Fix summary quick action to be disabled in demo mode.',
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
## What changed
- Disabled demo-mode quick actions for:
  - `Rate helpfulness` (`data-action="rateHelpfulness"`)
  - `Fix summary` (`data-action="fixSummary"`)
- Added demo-mode message guard coverage for both action types by extending:
  - `DEMO_MODE_IGNORED_WEBVIEW_MESSAGE_TYPES`
- Extended demo integration assertions in `test/integration/suite/demoResumeCard.js` to validate both actions are disabled.

## Why (cognitive rationale)
- Demo mode is intended to orient users quickly with **sample-only, low-risk context**.
- Leaving feedback/correction actions enabled in sample mode creates avoidable cognitive friction and side-effect confusion (actions look live but are not meaningful in demo context).
- Disabling these controls reduces ambiguity and keeps onboarding predictable and trust-building.

## How tested
- `npm run verify:quick`
- `npm run test:integration`

## How to verify manually
1. Run `TaCoS: Show Demo Resume Card`.
2. In `Notes & Feedback`, confirm `Rate helpfulness` and `Fix summary` are disabled.
3. Confirm no prompts/toasts/metrics-flow side effects occur when clicking those disabled buttons.
4. Confirm non-demo (`TaCoS: Show Resume Brief Now`) still allows normal feedback and fix flows.

## Performance impact notes
- No new background work or polling.
- Constant-time message-type guard additions only.
- No telemetry/network behavior changes (local-only behavior preserved).
