### PR TITLE
v0.6.1: Disable auto-summary toggle in demo mode to prevent config mutation (fixes #188)

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -220,6 +220,7 @@ const NOISE_BUDGET_BLOCK_CHECKPOINT_AFTER_SUMMARY_MS = 5 * 60_000;
 const DEMO_MODE_IGNORED_WEBVIEW_MESSAGE_TYPES = new Set<WebviewMessage['type']>([
   'fixSummary',
   'setPanelSectionExpanded',
+  'toggleAutoSummaries',
   'sessionAddCheckpoint',
   'checkpointOpenList',
   'openScratchpad',
@@ -702,6 +703,8 @@ export function activate(context: vscode.ExtensionContext): void {
         panelHtml,
       );
       const hasDisabledFixSummaryAction = /data-action="fixSummary"[^>]*disabled/u.test(panelHtml);
+      const hasDisabledToggleAutoSummariesAction =
+        /data-action="toggleAutoSummaries"[^>]*disabled/u.test(panelHtml);
       const disabledResumePathToggleCount = (
         panelHtml.match(/<input[^>]*data-resume-path-toggle="true"[^>]*disabled/gu) ?? []
       ).length;
@@ -774,6 +777,7 @@ export function activate(context: vscode.ExtensionContext): void {
         hasDisabledListNotesAction,
         hasDisabledRateHelpfulnessAction,
         hasDisabledFixSummaryAction,
+        hasDisabledToggleAutoSummariesAction,
       };
     }),
     vscode.commands.registerCommand('tacos.__test.getResumePathSnapshot', async () => {
@@ -4371,9 +4375,8 @@ function renderWebview(
   const autoSummaryToggleLabel = autoSummariesPaused
     ? 'Resume auto summaries'
     : 'Pause auto summaries';
-  const autoSummaryToggleDisabledAttr = autoSummariesDisabled
-    ? 'disabled aria-disabled="true"'
-    : '';
+  const autoSummaryToggleDisabledAttr =
+    autoSummariesDisabled || demoMode ? 'disabled aria-disabled="true"' : '';
   const timelineGroupsHtml = renderTimelineGroupsHtml({ timelineGroups });
   const timelineCard = renderTimelineCard({
     showTimeline: config.showTimeline,

--- a/test/integration/suite/demoResumeCard.js
+++ b/test/integration/suite/demoResumeCard.js
@@ -85,6 +85,11 @@ async function run() {
     true,
     'Expected Fix summary quick action to be disabled in demo mode.',
   );
+  assert.equal(
+    resumeFlow?.hasDisabledToggleAutoSummariesAction,
+    true,
+    'Expected auto-summary toggle controls to be disabled in demo mode.',
+  );
 }
 
 module.exports = {


### PR DESCRIPTION
## What changed
- Disabled `toggleAutoSummaries` controls when demo/sample resume mode is active.
- Added defense-in-depth host guard by ignoring `toggleAutoSummaries` messages in demo mode.
- Extended demo integration assertions to verify auto-summary toggles are disabled.

## Why (cognitive rationale)
- Demo mode should be orientation-first and side-effect-light.
- Allowing configuration toggles in sample mode can create accidental behavior changes and undermine user trust during onboarding.
- Disabling these controls keeps the demo predictable and reduces cognitive friction.

## How tested
- `npm run verify:quick`
- `npm run test:integration`

## How to verify manually
1. Run `TaCoS: Show Demo Resume Card`.
2. In Status/Trust cards, confirm auto-summary toggle buttons are disabled.
3. Confirm clicking toggle controls in demo mode does not pause/resume summaries.
4. Confirm non-demo resume view still allows normal pause/resume controls.

## Performance impact notes
- Constant-time message guard addition only.
- No new background work, no new telemetry, no network behavior changes.
