### PR TITLE
chore(release): prepare v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ All notable changes to this project are documented in this file.
 
 - No notable changes yet.
 
+## [0.7.0] - 2026-03-01
+
+### Added
+
+- Details panel accessibility baseline upgrades:
+  - semantic webview document shell (`lang`, title, viewport, color-scheme)
+  - skip link + `main` landmark navigation and live status region announcements
+  - stronger keyboard discoverability with in-panel shortcut help and improved focus visibility
+  - automated axe-core accessibility regression coverage for generated panel HTML
+- Responsive and scan-friendly panel structure:
+  - prioritized Companion Home layout for narrow split panes
+  - persistent progressive disclosure with a `More Context` section
+  - improved evidence/timeline affordances and non-color state cues for critical states
+- State resilience and regression hardening:
+  - persisted section expansion, evidence expansion, scroll, and focused-control restoration
+  - compatibility fixes for encoded focus tokens across URL/file evidence IDs
+  - guardrails/tests for scroll+focus restoration behavior across rerenders
+
+### Changed
+
+- Details panel interaction model now emphasizes a 5-second resume path (`what was I doing` and `what should I do next`) across narrow and wide layouts.
+- Restore-action unavailable messaging now distinguishes trust restrictions from missing history to reduce misleading remediation guidance.
+- Manual QA runbook and acceptance report were expanded for v0.7.0 UI/a11y/reflow sign-off and release gating.
+
 ## [0.6.1] - 2026-02-28
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-tacos",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-tacos",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "markdown-it": "^14.1.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "TaCoS Resume Brief",
   "description": "Auto task-context summaries when you resume work in VS Code.",
   "license": "MIT",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "publisher": "jkordish",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- bump extension version to `0.7.0`
- add `CHANGELOG.md` entry for `v0.7.0` (Details panel a11y, responsive hierarchy, resilience/test hardening)
- refresh lockfile version metadata

## Validation
- npm run verify:quick
