### PR TITLE
ci: avoid duplicate workflow runs on PR branch pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,11 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+    branches:
+      - main
 
 jobs:
   build-test-package:


### PR DESCRIPTION
## Summary
Stop duplicate CI runs for PR branch updates.

## What Changed
- Scoped `CI` workflow triggers in `.github/workflows/ci.yml`:
  - `push` now runs only on `main`
  - `pull_request` now runs only when targeting `main`

## Why
Previously, branch pushes for an open PR triggered both:
- `push` workflow run
- `pull_request` workflow run

This caused the same `build-test-package` job to run twice for each PR update.

## Expected Result
For PR updates, CI should run once (the `pull_request` run). Push-to-main still runs CI.
