### PR TITLE
DP-301: add one-click why-surfaced drill-down from Companion Home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable changes to this project are documented in this file.
 - Focus-triggered surface arbitration now runs through a deterministic notification broker (`none`/`statusbar`/`panel`/`notification`) with explicit reason enums and high-value-actionable notification gating; `tacos.uiSurface` remains a hard cap.
 - Companion Home now resolves policy output into fixed `Now/Next/Blocked/Restore` slots with deterministic single-primary CTA arbitration across `Next` and `Blocked`.
 - Companion `Next`/`Blocked` status captions now include explicit emphasis tokens (`PRIMARY`/`ADVISORY`/`SUPPRESSED`) with reduced-motion-safe transitions and forced-colors safeguards.
+- Companion Home now exposes a one-click `Why am I seeing this?` action that opens the Trust Center explainability trail (`More Context` → `Trust Center` → nested decision details).
 
 ## [0.7.0] - 2026-03-01
 

--- a/PLANS.md
+++ b/PLANS.md
@@ -91,7 +91,7 @@ Status vocabulary used in this file:
 
 ### P6. First recommended feature slice after stabilization
 
-- status: `doing`
+- status: `done`
 - why: deliver user-facing improvement without destabilizing trust/privacy boundaries.
 - scope: adaptive-surface dynamic-percolation slice for Epic `#226` (status semantics, surface broker, Companion slot policy, single-primary CTA arbitration, and emphasis tokens).
 - dependencies: P3, P4.
@@ -103,9 +103,7 @@ Status vocabulary used in this file:
   - completed DP-236 Companion Home slot policy wiring with deterministic source classes mapped into fixed `Now/Next/Blocked/Restore` slots.
   - completed DP-240 central single-primary CTA arbitration (`Next` vs `Blocked`) with advisory demotion and single-count primary CTA impression semantics.
   - completed DP-241 adaptive emphasis tokens (`PRIMARY`/`ADVISORY`/`SUPPRESSED`) with reduced-motion and forced-colors-safe presentation.
-- immediate next actions:
-  - land one PR that closes remaining Epic `#226` child issues (`#236`, `#238`, `#239`, `#240`, `#241`).
-  - update Epic `#226` checklist/status after merge and move to next open epic slice.
+  - merged final Epic `#226` PR and closed Epic `#226` with completed child issues.
 - risks/rollback:
   - risk: over-aggressive suppression hides useful cues.
   - rollback: revert to previous ranking/suppression default behavior.
@@ -119,6 +117,27 @@ Status vocabulary used in this file:
   - https://github.com/jkordish/vscode-tacos/issues/240
   - https://github.com/jkordish/vscode-tacos/issues/241
   - https://github.com/jkordish/vscode-tacos/pull/267
+
+### P7. Trust/privacy explainability drill-down
+
+- status: `doing`
+- why: preserve trust by making surfaced-decision rationale available immediately from Companion Home.
+- scope: Epic `#227`, starting with DP-301 / issue `#242` (one-click `Why am I seeing this?` path from top card plus Trust Center explainability parity).
+- dependencies: P3, P4.
+- recent progress:
+  - identified existing explainability payload + Trust Center nested disclosure plumbing (`evidence IDs`, suppression reason when present, why-surfaced open counter hook).
+  - confirmed gap is top-card one-click affordance and fast expansion path to Trust Center explainability.
+- immediate next actions:
+  - land DP-301 top-card `Why am I seeing this?` action and one-click expansion behavior.
+  - run unit/integration checks and close issue `#242` once merged.
+- risks/rollback:
+  - risk: explainability copy could become overly verbose.
+  - rollback: keep top-card affordance while tightening detail copy and disclosure defaults.
+- links:
+  - `docs/ux/dynamic-percolation-v0.8.0-spec.md`
+  - `docs/roadmap/v0.8.0-dynamic-percolation-issues.md`
+  - https://github.com/jkordish/vscode-tacos/issues/227
+  - https://github.com/jkordish/vscode-tacos/issues/242
 
 ## Blockers
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ TaCoS is desktop-first today. It runs in the Node-hosted VS Code extension runti
 - Companion Home keeps fixed `Now`, `Next`, `Blocked`, and `Restore` slot order for scan stability.
 - Exactly one primary CTA is marked per context across `Next` and `Blocked`; non-primary actions remain available as advisory/secondary controls.
 - `Next` and `Blocked` state captions render explicit emphasis tokens (`PRIMARY`, `ADVISORY`, `SUPPRESSED`) with reduced-motion-safe transitions.
+- Companion Home includes a one-click `Why am I seeing this?` action that opens `More Context` → `Trust Center` → `Why am I seeing this?` explainability details.
 
 ## Status Bar Behavior
 

--- a/SPECS.md
+++ b/SPECS.md
@@ -317,12 +317,14 @@ Companion Home top-card content and CTA priority were previously composed from s
 - Primary CTA precedence is deterministic (`blocked` actionable > `next` actionable > none).
 - Demoted/non-primary actions remain visible as secondary/advisory controls.
 - Advisory-only labeling is explicit when no safe primary action is available.
+- Top-card `Why am I seeing this?` action opens `More Context` and expands `Trust Center` explainability in one click.
 
 ### Technical shape / architecture notes
 
 - Central arbitration utility in `src/companionPrimaryCta.ts`.
 - `renderWebview` in `src/extension.ts` resolves one `CompanionPrimaryCtaDecision` and passes slot source classes + emphasis tokens into `renderResumeStackCard`.
 - Primary CTA impression metric remains single-count per context and stores policy source class.
+- `openWhySurfaced` is handled in `src/webview/panelClientScript.ts` and expands `moreContext`, `trustCenter`, and nested why-surfaced disclosures without bypassing trust/privacy guards.
 
 ### Settings and commands affected
 

--- a/docs/DESIGN_AND_IMPLEMENTATION.md
+++ b/docs/DESIGN_AND_IMPLEMENTATION.md
@@ -54,6 +54,7 @@ Principles:
 - Status bar semantics are compact and policy-driven (`class + reason`) so ambient state remains stable; active-mode elevation is reserved for rare high-risk blocked states.
 - Focus-triggered summary presentation now runs through a deterministic surface broker (`none` vs `statusbar` vs `panel` vs `notification`) with explicit reason enums; `tacos.uiSurface` remains a hard cap/user override.
 - Companion Home keeps fixed `Now/Next/Blocked/Restore` slot order while a central CTA arbiter enforces one primary action across `Next` and `Blocked`; emphasis tokens (`PRIMARY`/`ADVISORY`/`SUPPRESSED`) are motion-safe and a11y-aware.
+- Companion Home includes a one-click `Why am I seeing this?` action that expands `More Context` and the nested Trust Center explainability disclosure.
 - Command palette and keybinding surfaces.
 - Collapsible panel sections keep stable order and persisted expansion state; policy emphasis is conveyed via summary badges/accent instead of auto-expansion or reordering, and only targets sections currently rendered by settings/trust mode.
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5579,6 +5579,8 @@ function renderWebview(
       nextPrimaryCtaSourceClass: hasPrimaryNextAction ? companionSlotSources.primaryCta : undefined,
       nextEmphasisToken: primaryCtaDecision.nextToken,
       primaryNextActionTrustedHtml: companionPrimaryNextActionButton,
+      whySurfacedActionTrustedHtml:
+        '<button type="button" class="secondary" data-action="openWhySurfaced">Why am I seeing this?</button>',
       nextStepRationaleTrustedHtml: primaryNextStepRationaleHtml,
       nextStepsListTrustedHtml: companionNextSteps,
       hasBlocker: blockerDecision.hasBlocker,

--- a/src/resumeStackCard.ts
+++ b/src/resumeStackCard.ts
@@ -37,6 +37,7 @@ export interface RenderResumeStackCardInput {
   nextPrimaryCtaSourceClass?: string;
   nextEmphasisToken?: CompanionSlotToken;
   primaryNextActionTrustedHtml?: TrustedHtml;
+  whySurfacedActionTrustedHtml?: TrustedHtml;
   nextStepRationaleTrustedHtml?: TrustedHtml;
   nextStepsListTrustedHtml: TrustedHtml;
   hasBlocker: boolean;
@@ -112,6 +113,7 @@ export function renderResumeStackCard(input: RenderResumeStackCardInput): string
           }</ul>
           <div class="status-actions">
             ${input.primaryNextActionTrustedHtml ?? ''}
+            ${input.whySurfacedActionTrustedHtml ?? ''}
             <button type="button" class="secondary" data-action="copyNextSteps">Copy next steps</button>
             <button type="button" class="secondary" data-action="copyPromptAndOpenCodex">Copy prompt + open Codex</button>
           </div>

--- a/src/webview/panelClientScript.ts
+++ b/src/webview/panelClientScript.ts
@@ -559,6 +559,38 @@ export function renderPanelClientScript(
             return;
           }
 
+          if (action === 'openWhySurfaced') {
+            const moreContext = document.querySelector(
+              'details[data-panel-section="moreContext"]',
+            );
+            if (moreContext instanceof HTMLDetailsElement) {
+              moreContext.open = true;
+            }
+
+            const trustCenter = document.querySelector(
+              'details[data-panel-section="trustCenter"]',
+            );
+            if (trustCenter instanceof HTMLDetailsElement) {
+              trustCenter.open = true;
+            }
+
+            const whySurfaced = document.querySelector('details[data-why-surfaced-details="true"]');
+            if (whySurfaced instanceof HTMLDetailsElement) {
+              whySurfaced.open = true;
+
+              const whySurfacedSummary = whySurfaced.querySelector('summary');
+              if (whySurfacedSummary instanceof HTMLElement) {
+                whySurfacedSummary.focus();
+                if (typeof whySurfacedSummary.scrollIntoView === 'function') {
+                  whySurfacedSummary.scrollIntoView({ block: 'start' });
+                }
+              }
+            }
+
+            announceStatus('Opened Why am I seeing this? details.');
+            return;
+          }
+
           if (action === 'openTopFile') {
             const index = parseDatasetInteger(actionElement.dataset.topFileIndex);
             if (index === undefined) {

--- a/test/panelClientScript.state.test.ts
+++ b/test/panelClientScript.state.test.ts
@@ -45,9 +45,19 @@ describe('panelClientScript state behavior', () => {
       <main id="main" tabindex="-1"></main>
       <ul id="evidence-list"><li class="extra-evidence">more evidence</li></ul>
       <button type="button" data-action="toggleEvidenceMore" data-hidden-count="1">Show 1 more</button>
+      <button type="button" data-action="openWhySurfaced">Why am I seeing this?</button>
       <button type="button" data-test-slot="primary" data-action="openEvidence" data-evidence-id="url:https://example.test/search?q=a=b&mode=full">Open evidence</button>
       <button type="button" data-test-slot="duplicate" data-action="openEvidence" data-evidence-id="url:https://example.test/search?q=a=b&mode=full">Open evidence duplicate</button>
       <button type="button" data-test-slot="pipe" data-action="openEvidence" data-evidence-id="file:src/foo|bar.ts">Open pipe evidence</button>
+      <details data-panel-section="moreContext">
+        <summary>More Context</summary>
+        <details data-panel-section="trustCenter">
+          <summary>Trust Center</summary>
+          <details data-why-surfaced-details="true">
+            <summary>Why am I seeing this?</summary>
+          </details>
+        </details>
+      </details>
       <details data-panel-section="timeline"></details>
       <input id="intent-override-input" type="text" value="intent" />
     `;
@@ -107,6 +117,31 @@ describe('panelClientScript state behavior', () => {
         sectionExpanded: expect.objectContaining({ timeline: true }),
       }),
     );
+  });
+
+  it('opens the Why Surfaced drill-down from Companion Home in one click', () => {
+    bootstrap();
+    const openWhySurfacedButton = document.querySelector(
+      '[data-action="openWhySurfaced"]',
+    ) as HTMLButtonElement;
+    const moreContext = document.querySelector(
+      'details[data-panel-section="moreContext"]',
+    ) as HTMLDetailsElement;
+    const trustCenter = document.querySelector(
+      'details[data-panel-section="trustCenter"]',
+    ) as HTMLDetailsElement;
+    const whySurfaced = document.querySelector(
+      'details[data-why-surfaced-details="true"]',
+    ) as HTMLDetailsElement;
+    const live = document.getElementById('panel-status-live') as HTMLElement;
+
+    openWhySurfacedButton.click();
+    jest.advanceTimersByTime(20);
+
+    expect(moreContext.open).toBe(true);
+    expect(trustCenter.open).toBe(true);
+    expect(whySurfaced.open).toBe(true);
+    expect(live.textContent).toBe('Opened Why am I seeing this? details.');
   });
 
   it('persists focus and scroll state for rerender restoration', () => {

--- a/test/panelClientScript.test.ts
+++ b/test/panelClientScript.test.ts
@@ -30,6 +30,11 @@ describe('renderPanelClientScript', () => {
     expect(script).toContain('hashTarget.focus();');
     expect(script).toContain("actionElement.dataset.blockerPrimaryAction === 'true'");
     expect(script).toContain("vscode.postMessage({ type: action, primarySurface: 'blocked' });");
+    expect(script).toContain("if (action === 'openWhySurfaced')");
+    expect(script).toContain('details[data-panel-section="moreContext"]');
+    expect(script).toContain('details[data-panel-section="trustCenter"]');
+    expect(script).toContain('details[data-why-surfaced-details="true"]');
+    expect(script).toContain("announceStatus('Opened Why am I seeing this? details.')");
     expect(script).toContain(
       'if (!event.altKey || !event.shiftKey || event.metaKey || event.ctrlKey)',
     );

--- a/test/resumeStackCard.test.ts
+++ b/test/resumeStackCard.test.ts
@@ -15,6 +15,8 @@ describe('renderResumeStackCard', () => {
       hasPrimaryNextAction: true,
       primaryNextActionTrustedHtml:
         '<button type="button" data-primary-next-safe-action="home" data-action="runNextStepAction" data-step-index="0">Open file</button>',
+      whySurfacedActionTrustedHtml:
+        '<button type="button" class="secondary" data-action="openWhySurfaced">Why am I seeing this?</button>',
       nextStepRationaleTrustedHtml:
         '<details><summary><strong>Why this next step?</strong></summary><p class="muted" data-next-step-rationale="true">Based on file evidence: src/extension.ts.</p></details>',
       nextStepsListTrustedHtml: '',
@@ -54,6 +56,7 @@ describe('renderResumeStackCard', () => {
                <ul class="compact-list"><li>No next steps captured yet.</li></ul>
                <div class="status-actions">
                  <button type="button" data-primary-next-safe-action="home" data-action="runNextStepAction" data-step-index="0">Open file</button>
+                 <button type="button" class="secondary" data-action="openWhySurfaced">Why am I seeing this?</button>
                  <button type="button" class="secondary" data-action="copyNextSteps">Copy next steps</button>
                  <button type="button" class="secondary" data-action="copyPromptAndOpenCodex">Copy prompt + open Codex</button>
                </div>
@@ -92,6 +95,8 @@ describe('renderResumeStackCard', () => {
       hasPrimaryNextAction: true,
       primaryNextActionTrustedHtml:
         '<button type="button" data-primary-next-safe-action="home" data-action="runNextStepAction" data-step-index="0">Open Problems</button>',
+      whySurfacedActionTrustedHtml:
+        '<button type="button" class="secondary" data-action="openWhySurfaced">Why am I seeing this?</button>',
       nextStepRationaleTrustedHtml: '',
       nextStepsListTrustedHtml: '<li>Run focused verify pass</li>',
       hasBlocker: true,
@@ -119,6 +124,7 @@ describe('renderResumeStackCard', () => {
     expect(html).toContain('data-action="restoreOpenProblems"');
     expect(html).toContain('data-blocker-primary-action="true"');
     expect(html).toContain('data-primary-next-safe-action="home"');
+    expect(html).toContain('data-action="openWhySurfaced"');
     expect(html).toContain('<li>Run focused verify pass</li>');
   });
 });


### PR DESCRIPTION
## Summary
- add a top-card `Why am I seeing this?` action in Companion Home (`Next` section)
- wire `openWhySurfaced` in panel client script to one-click expand `More Context` -> `Trust Center` -> nested why-surfaced details
- keep existing explainability payload usage in Trust Center (including evidence IDs and suppression reason when present)
- update docs parity (`README`, `SPECS`, design guide, changelog, plans ledger)
- add/update tests for resume stack rendering and panel client behavior

## Validation
- npm run format:check
- npm run lint
- npm run typecheck
- npm test

Closes #242
Part of #227
