### PR TITLE
Release: disable Marketplace automation pre-v1.0

### DIFF
--- a/.github/workflows/release-vsix.yml
+++ b/.github/workflows/release-vsix.yml
@@ -45,7 +45,3 @@ jobs:
           tag_name: ${{ github.ref_name }}
           generate_release_notes: true
           files: ${{ env.VSIX_FILE }}
-
-      - name: Publish to VS Code Marketplace (optional)
-        if: ${{ secrets.VSCE_PAT != '' }}
-        run: npx @vscode/vsce publish -p "${{ secrets.VSCE_PAT }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,7 @@ Run `npm run package:vsix` when touching packaging, manifest metadata, workflow/
 
 - `main` must remain verify-clean and packageable.
 - Tag workflow must produce a VSIX artifact.
-- Marketplace publish is optional and credential-gated (`VSCE_PAT`), with explicit docs for missing config.
+- Marketplace publish is intentionally disabled before `v1.0`; do not add workflow publish steps or `VSCE_PAT` requirements in this phase.
 
 ## Guardrails For Humans and AI Agents
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ All notable changes to this project are documented in this file.
 
 - Build pipeline now separates bundling (`npm run build`) from static type checks (`npm run typecheck`).
 - Verification and CI workflows now run format/lint/typecheck/unit gates before integration/package checks.
-- Release workflow now supports optional VS Code Marketplace publish when `VSCE_PAT` is configured.
+- Release workflow now focuses on tag-based VSIX artifact + GitHub release creation; Marketplace publish automation is disabled before `v1.0`.
 - README is now a concise landing page; detailed behavior/contracts are linked to focused docs in `docs/*`.
 - README/operator docs now align with current Trust/Privacy/provider boundaries and troubleshooting flow.
 - Panel-emphasis policy now avoids targeting hidden `Timeline` sections when `tacos.showTimeline` is disabled, and integration snapshot section-order parsing now reads rendered disclosure markup only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,4 +65,4 @@ Use `.github/PULL_REQUEST_TEMPLATE.md` (or equivalent template path in this repo
 
 - keep `main` verify-clean and packageable,
 - keep tag workflow artifact generation working,
-- direct marketplace publish requires maintainers to configure `VSCE_PAT`.
+- do not wire Marketplace publish automation before `v1.0`; release flow is VSIX artifact + GitHub release only in this phase.

--- a/PLANS.md
+++ b/PLANS.md
@@ -271,6 +271,26 @@ Status vocabulary used in this file:
   - https://github.com/jkordish/vscode-tacos/issues/227
   - https://github.com/jkordish/vscode-tacos/issues/229
 
+### P14. Release workflow policy hardening (`v0.8.x`)
+
+- status: `done`
+- why: keep tag-based VSIX releases reliable while deferring Marketplace automation until `v1.0`.
+- scope: remove Marketplace publish step from release workflow, and align operator/release docs to explicit pre-`v1.0` no-Marketplace policy.
+- dependencies: P1, P5.
+- recent progress:
+  - removed Marketplace publish step from `.github/workflows/release-vsix.yml` so tag workflow only builds/packages and attaches VSIX to GitHub release.
+  - updated operator/release docs (`AGENTS.md`, `CONTRIBUTING.md`, `docs/DESIGN_AND_IMPLEMENTATION.md`) to codify “no Marketplace automation before `v1.0`”.
+  - refreshed `CHANGELOG.md` wording to match current release automation posture.
+- risks/rollback:
+  - risk: future maintainers may reintroduce publish steps without updating policy docs.
+  - rollback: reintroduce a publish step only when `v1.0` policy is explicitly approved and docs/contracts are updated in the same PR.
+- links:
+  - `.github/workflows/release-vsix.yml`
+  - `AGENTS.md`
+  - `CONTRIBUTING.md`
+  - `docs/DESIGN_AND_IMPLEMENTATION.md`
+  - `CHANGELOG.md`
+
 ## Blockers
 
 - none currently.

--- a/docs/DESIGN_AND_IMPLEMENTATION.md
+++ b/docs/DESIGN_AND_IMPLEMENTATION.md
@@ -192,4 +192,4 @@ Quality gates:
 - `npm run package:vsix` produces VSIX using `vsce`.
 - CI validates formatting/lint/typecheck/unit/integration/package smoke.
 - Tag workflow attaches VSIX artifacts.
-- Marketplace publish is credential-gated and documented as optional (`VSCE_PAT`).
+- Marketplace publish automation is intentionally disabled before `v1.0`; release flow remains VSIX artifact + GitHub release.


### PR DESCRIPTION
## Summary
- remove Marketplace publish step from `.github/workflows/release-vsix.yml`
- keep tag workflow focused on VSIX build + GitHub release artifact attach
- align operator/release docs with explicit policy: no Marketplace automation before `v1.0`
  - `AGENTS.md`
  - `CONTRIBUTING.md`
  - `docs/DESIGN_AND_IMPLEMENTATION.md`
  - `CHANGELOG.md`
  - `PLANS.md`

## Why
Release workflow runs were failing due workflow-file validation around the optional Marketplace publish path. This removes that path entirely for the `v0.8.x` phase and keeps release automation deterministic.

## Validation
- `npm run format:check`
- `npm run verify:quick`
- `npm run package:vsix`

## Follow-up after merge
- Existing `v0.8.0` tag points to commit `2de2ad8` (pre-fix workflow), so its release run remains failed.
- If you want `v0.8.0` release automation to rerun with this fix, we should move/recreate tag `v0.8.0` after merge (force-update) or cut `v0.8.1`.
