### PR TITLE
fix(integration): add data-resume-path-card marker for resumeFlowCriticalPath assertion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1426,7 +1426,7 @@ export function activate(context: vscode.ExtensionContext): void {
         evidenceExpanded,
         detailsExpanded,
         moreContextExpanded,
-        hasResumePathCard: panelHtml.includes('<h3>Resume Path</h3>'),
+        hasResumePathCard: panelHtml.includes('data-resume-path-card="true"'),
         resumePathStepCount: (panelHtml.match(/<input[^>]*data-resume-path-toggle="true"/gu) ?? [])
           .length,
         disabledResumePathToggleCount,

--- a/src/webview/panelFragments.ts
+++ b/src/webview/panelFragments.ts
@@ -545,7 +545,7 @@ export function renderResumePathCard(input: ResumePathCardInput): string {
   const progressLabel = input.completed
     ? 'All steps complete ✓'
     : `${completedStepCount} of ${totalStepCount} steps done`;
-  return `<div class="card"${readOnlyAttr}>
+  return `<div class="card" data-resume-path-card="true"${readOnlyAttr}>
       <h3>Resume Path <span class="badge ${input.completed ? 'badge-done' : ''}">${escapeHtml(progressLabel)}</span></h3>
       <details data-resume-path-details="true" ${input.completed && input.collapsed ? '' : 'open'}>
         <summary class="panel-disclosure-summary"><span class="section-heading-inline">${


### PR DESCRIPTION
Adds `data-resume-path-card="true"` attribute to `renderResumePathCard` outer div and updates the `hasResumePathCard` probe in `getResumeFlowSnapshot` to match it. The previous probe checked for `<h3>Resume Path</h3>` which was never rendered (the h3 always contains a badge child span). This fixes the `resumeFlowCriticalPath` integration test CI failure.