### PR TITLE
chore: release v0.99.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project are documented in this file.
 
-## [Unreleased]
+## [0.99.2] - 2026-04-05
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # vscode-tacos
 
-**TaCoS Resume Brief** — `v0.99.1`
+**TaCoS Resume Brief** — `v0.99.2`
 
 TaCoS is a desktop-first, VS Code-first, local-first extension for cognitive state recovery after interruptions.
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "TaCoS Resume Brief",
   "description": "Calm ambient resume cues with deep trust/evidence drill-down when you need it.",
   "license": "MIT",
-  "version": "0.99.1",
+  "version": "0.99.2",
   "publisher": "jkordish",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.99.2 release

Version bump and CHANGELOG promotion for the UX polish rounds merged in PR #295.

### Changes in this release
- UX polish rounds 6–10 (branch `fix/ux-ui-polish`): companion grid a11y, caret disclosure CSS, selector narrowing for `.companion-block p`, snapshot field renames (`hasResumeBriefCard` / `isResumeBriefFirstCard`), `hasCognitiveDebriefCard` Mental Load compat, README terminology updates.

### Verification
- `npm run verify:quick` clean: 56 suites / 403 tests ✓