### PR TITLE
chore: release v0.99.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.99.4] - 2026-04-06
+
+### Changed
+
+- Demo resume card (`buildDemoResumeSummary`) polish pass (branch `ux/demo-card-realistic-content`):
+  - Evidence items `file:ranking` and `file:broker` changed from `kind: 'file'` to `kind: 'git'` — file-kind items are clickable and fail in demo mode (no workspace root); git-kind items are non-clickable and safe.
+  - Branch label direction corrected: `feat/percolation-surface-v2 → main` → `main → feat/percolation-surface-v2`.
+  - `detailsMarkdown` intent line made consistent with the `intent` field: `"add full unit coverage"` → `"add unit coverage"`.
+
 ## [0.99.3] - 2026-04-06
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-tacos",
-  "version": "0.99.3",
+  "version": "0.99.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-tacos",
-      "version": "0.99.3",
+      "version": "0.99.4",
       "license": "MIT",
       "dependencies": {
         "markdown-it": "^14.1.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "TaCoS Resume Brief",
   "description": "Calm ambient resume cues with deep trust/evidence drill-down when you need it.",
   "license": "MIT",
-  "version": "0.99.3",
+  "version": "0.99.4",
   "publisher": "jkordish",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.99.4

Demo resume card polish pass (follow-up to #303).

### Changes
- Evidence items `file:ranking` and `file:broker` changed from `kind: 'file'` to `kind: 'git'` — file-kind items are clickable and fail in demo mode (no workspace root); git-kind items are non-clickable and safe.
- Branch label direction corrected: `feat/percolation-surface-v2 → main` → `main → feat/percolation-surface-v2`.
- `detailsMarkdown` intent line made consistent with the `intent` field: `"add full unit coverage"` → `"add unit coverage"`.

### Verification
- `npm run verify:quick`: 56 suites / 403 tests ✅
- CHANGELOG and package.json bumped to `0.99.4`.