### PR TITLE
chore(release): v0.99.5 — 4-tab panel redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.99.5] - 2026-04-07
+
+### Changed
+
+- 4-tab panel redesign (branch `ux/tab-redesign`):
+  - Details panel now uses a 4-tab layout: **Overview**, **Resume**, **Evidence**, and **Debrief** — replacing the single-scroll card stack with a navigable tab interface.
+  - `renderWebviewDocument` accepts a `tabs` option to render a `<nav role="tablist">` + `<div class="tab-panels">` document shell with ARIA-compliant tab buttons (`role="tab"`, `aria-selected`, `aria-controls`) and hidden non-default panels (`hidden` attribute).
+  - `renderPageHeader` added: renders a sticky `<header class="page-header">` with intent text, status chips, optional secondary chip, and an optional actions row. Page header is emitted before the tab nav when `pageHeaderTrustedHtml` is provided to `renderWebviewDocument`.
+  - `panelClientScript.ts` additions:
+    - `updatePageHeaderHeight()` measures the rendered `.page-header` element and writes `--page-header-height` on `:root` so `.page-tabs` can use `top: var(--page-header-height, 0px)` for correct sticky positioning beneath the header.
+    - `restoreViewPosition()` now detects when a focus target is inside a hidden `.tab-panel[hidden]` and switches to that tab before attempting focus/scroll restoration.
+  - `panelStyles.ts` updates:
+    - `.header-intent` resets default `<h1>` margins (`margin: 0; padding: 0`).
+    - `.page-tabs` uses `top: var(--page-header-height, 0px)` for sticky positioning relative to the page header.
+  - Page header `checkpointOpenList` Notes button added to `pageHeaderActionButtons` array in `extension.ts`.
+  - Integration test `panelSectionPersistence.js` updated to reflect 4-tab navigation and tab-switch state persistence.
+  - Demo screenshot (`assets/demo.png`) updated to show 4-tab UI.
+
 ## [0.99.4] - 2026-04-06
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-tacos",
-  "version": "0.99.4",
+  "version": "0.99.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-tacos",
-      "version": "0.99.4",
+      "version": "0.99.5",
       "license": "MIT",
       "dependencies": {
         "markdown-it": "^14.1.1"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "TaCoS Resume Brief",
   "description": "Calm ambient resume cues with deep trust/evidence drill-down when you need it.",
   "license": "MIT",
-  "version": "0.99.4",
+  "version": "0.99.5",
   "publisher": "jkordish",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## v0.99.5

Bumps version to `0.99.5` and adds CHANGELOG entry for the 4-tab panel redesign landed in PR #306.

### Changes
- `package.json` / `package-lock.json`: version → `0.99.5`
- `CHANGELOG.md`: `[0.99.5] - 2026-04-07` entry documenting the 4-tab UI redesign

### What shipped in the 4-tab redesign (ux/tab-redesign, merged to main)
- Details panel replaced with **Overview / Resume / Evidence / Debrief** tab layout
- `renderWebviewDocument` `tabs` option: ARIA-compliant `role="tablist"` + `role="tabpanel"` shell
- `renderPageHeader`: sticky intent header with chips and optional actions row
- `updatePageHeaderHeight()` + `--page-header-height` CSS custom property for correct sticky tab positioning
- `restoreViewPosition()` tab-aware hidden-panel detection and auto-switch
- `.header-intent` margin reset; `.page-tabs` sticky `top: var(--page-header-height, 0px)`
- `checkpointOpenList` Notes button wired into `pageHeaderActionButtons`
- Updated `assets/demo.png` screenshot
- `panelSectionPersistence` integration test updated for 4-tab navigation

### Verification
- `npm run verify:quick`: ✅ 56 suites / 410 tests pass
- Tag `v0.99.5` already pushed