### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "TaCoS Resume Brief",
   "description": "Calm ambient resume cues with deep trust/evidence drill-down when you need it.",
   "license": "MIT",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "publisher": "jkordish",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump `package.json` version from `1.0.0` to `1.0.1` so the release VSIX asset is named `vscode-tacos-1.0.1.vsix` when the `v1.0.1` tag workflow runs.